### PR TITLE
2023-09-11 changes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+## 2023-09-10
+
+1. Revised section 4 (conformance targets)
+2. Revised section 10.10 (NIEM structural facilities)
+3. Resurrected rule 11-23 (turns out NDR is much easier to write with SimpleObjectAttributeGroup)
+4. Wrote "makerules" script to generate SCH files from niem-ndr.md
+5. Replaced appendix B (structures namespace)
+
 ## 2023-09-04
 
 1. Replaced niem.org URIs with oasis-open.org URIs

--- a/genruleMatrix
+++ b/genruleMatrix
@@ -1,0 +1,56 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+open(NDR, "niem-ndr.md")   or die "can't open niem-ndr: $!\n";
+open(RM, ">ruleMatrix.md") or die "can't open ruleMatrix.md: $!\n";
+
+my @lines;
+my $line;
+my $rsn;
+my $header = <<"EOS";
+| Number | Rule | REF | EXT | SUB | MSG |
+| --- | --- | :-: | :-: | :-: | :-: |
+EOS
+
+while (<NDR>) {
+  chop;
+  if (/# Rule (\d+-\d+)\. /) {
+    $rsn = $1;
+    my $rn = $1;
+    my $rt = $';
+    $rsn =~ s/^\d-/0$&/;
+    $rsn =~ s/-(\d)$/-0$1/;
+    $line = "| $rn | $rt ";
+  }
+  if ($line && /> \*\*\[Rule/) {
+    my $m = 0;
+    /REF/ && $m++;
+    /EXT/ && $m++;
+    /SUB/ && $m++;
+    /MSG/ && $m++;
+    $line .= /REF/ ? " | X" : " |  ";
+    $line .= /EXT/ ? " | X" : " |  ";
+    $line .= /SUB/ ? " | X" : " |  ";
+    $line .= /MSG/ ? " | X" : " |  ";
+    push @lines, "$m$rsn $line |" if $m > 0;
+    $line="";
+  }
+}
+my $last = 0;
+foreach $line (sort @lines) {
+  $line =~ s/^(.)......//;
+  my $m = $1;
+  next if $line =~ /^\| 4/;
+  if ($last ne $m) {
+    print RM "\n**Applicable only to reference schema documents**\n\n" if $m == 1;
+    print RM "\n**Applicable to reference and extension schema documents**\n\n" if $m == 2;
+    print RM "\n**Applicable to reference, extension, and subset schema documents**\n\n" if $m == 3;
+    print RM "\n**Applicable to all schema documents**\n\n" if $m == 4;
+    print RM $header;
+    $last = $m;
+  }
+  print RM "$line\n";
+}
+

--- a/makerules
+++ b/makerules
@@ -1,0 +1,84 @@
+#!/usr/bin/perl
+
+# Create schematron rules from NDR
+
+use warnings;
+use strict;
+
+my $header = <<"EOSTRING";
+<?xml version="1.0" encoding="US-ASCII" standalone="yes"?>
+<sch:schema
+  xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform" queryBinding="xslt2">
+<sch:title>Rules for reference XML Schema documents</sch:title>
+<xsl:include href="ndr-functions.xsl"/>
+<sch:ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
+<sch:ns prefix="xsl" uri="http://www.w3.org/1999/XSL/Transform"/>
+<sch:ns prefix="nf" uri="https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#NDRFunctions"/>
+<sch:ns prefix="ct" uri="https://docs.oasis-open.org/niemopen/ns/specification/conformanceTargets/3.0/"/>
+<sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+<sch:ns prefix="appinfo" uri="https://docs.oasis-open.org/niemopen/ns/model/appinfo/6.0/"/>
+<sch:ns prefix="structures" uri="https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/"/>
+EOSTRING
+
+my $rnum   = '';
+my $title  = '';
+my $ctargs = '';
+my $rule   = '';
+
+open(NDR, "niem-ndr.md") or die "can't open niem-ndr.md: $!\n";
+open(REF, ">ndr-ct-ref.sch") or die "can't open ndr-ct-ref.sch: $!\n";
+open(EXT, ">ndr-ct-ext.sch") or die "can't open ndr-ct-ext.sch: $!\n";
+open(SUB, ">ndr-ct-sub.sch") or die "can't open ndr-ct-sub.sch: $!\n";
+open(MSG, ">ndr-ct-msg.sch") or die "can't open ndr-ct-msg.sch: $!\n";
+
+print REF $header;
+$header =~ s/reference/extension/; print EXT $header;
+$header =~ s/extension/subset/;    print SUB $header;
+$header =~ s/subset/message/;      print MSG $header;
+
+while (<NDR>) {
+  chop;
+  if (m/^#/) {
+    $title = $ctargs = $rule = '';
+  }
+  if (m/^#+ Rule (\d+-\d+)\.\s*/) {
+    $rnum = $1;
+    $title = $';
+    $title =~ tr/`//d;
+  }
+  elsif ($title && m/^> \*\*\[Rule /) {
+    $ctargs = $_;
+  }
+  elsif ($title && $ctargs && !$rule && m/^> ```/) {
+    $rule = ' ';
+  }
+  elsif ($rule && !m/^> ```/) {
+    $rule .= "\n$_";
+  }
+  elsif ($rule && m/^> ```/) {
+    dorule($title, $ctargs, $rule);
+  }
+  elsif (m/^> ```/) {
+    $title = $ctargs = $rule = '';
+  }
+}
+print REF "</sch:schema>\n";
+print EXT "</sch:schema>\n";
+print SUB "</sch:schema>\n";
+print MSG "</sch:schema>\n";
+
+
+sub dorule {
+  my ($title, $ctarg, $rule) = @_;
+  $rule =~ s/^ \n//;
+  $rule =~ s/^> //mg;
+  $rule =~ s!<sch:pattern>!<sch:pattern id="rule_$rnum"><sch:title>$title</sch:title>!;
+  $rule =~ s!>([^<]+</sch:assert>)!>Rule $rnum: $1!;
+
+  print REF $rule if $ctarg =~ m/\[REF\]/;
+  print EXT $rule if $ctarg =~ m/\[EXT\]/;
+  print SUB $rule if $ctarg =~ m/\[SUB\]/;
+  print MSG $rule if $ctarg =~ m/\[MSG\]/;
+}

--- a/ndr-ct-ext.sch
+++ b/ndr-ct-ext.sch
@@ -1,0 +1,1030 @@
+<?xml version="1.0" encoding="US-ASCII" standalone="yes"?>
+<sch:schema
+  xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform" queryBinding="xslt2">
+<sch:title>Rules for extension XML Schema documents</sch:title>
+<xsl:include href="ndr-functions.xsl"/>
+<sch:ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
+<sch:ns prefix="xsl" uri="http://www.w3.org/1999/XSL/Transform"/>
+<sch:ns prefix="nf" uri="https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#NDRFunctions"/>
+<sch:ns prefix="ct" uri="https://docs.oasis-open.org/niemopen/ns/specification/conformanceTargets/3.0/"/>
+<sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+<sch:ns prefix="appinfo" uri="https://docs.oasis-open.org/niemopen/ns/model/appinfo/6.0/"/>
+<sch:ns prefix="structures" uri="https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/"/>
+<sch:pattern id="rule_4-6"><sch:title>Document element has attribute ct:conformanceTargets</sch:title>
+ <sch:rule context="*[. is nf:get-document-element(.)
+                      or exists(@ct:conformanceTargets)]">
+   <sch:assert test="(. is nf:get-document-element(.)) = exists(@ct:conformanceTargets)"
+     >Rule 4-6: The [document element] of the XML document, and only the [document element], MUST own an attribute {https://docs.oasis-open.org/niemopen/ns/specification/conformanceTargets/3.0/}conformanceTargets.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_4-8"><sch:title>Schema claims extension conformance target</sch:title>
+ <sch:rule context="*[. is nf:get-document-element(.)]">
+   <sch:assert test="nf:has-effective-conformance-target-identifier(., xs:anyURI(https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#ExtensionSchemaDocument'))"
+     >Rule 4-8: The document MUST have an effective conformance target identifier of https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#ExtensionSchemaDocument.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-1"><sch:title>No base type in the XML namespace</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="namespace-uri-from-QName(resolve-QName(@base, .)) != xs:anyURI('http://www.w3.org/XML/1998/namespace')"
+     >Rule 9-1: A schema component must not have a base type definition with a {target namespace} that is the XML namespace.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-2"><sch:title>No base type of xs:ID</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:ID')"
+     >Rule 9-2: A schema component MUST NOT have an attribute {}base with a value of xs:ID.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-3"><sch:title>No base type of xs:IDREF</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:IDREF')"
+     >Rule 9-3: A schema component MUST NOT have an attribute {}base with a value of xs:IDREF.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-4"><sch:title>No base type of xs:IDREFS</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:IDREFS')"
+     >Rule 9-4: A schema component MUST NOT have an attribute {}base with a value of xs:IDREFS.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-5"><sch:title>No base type of xs:anyType</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:anyType')"
+     >Rule 9-5: A schema component MUST NOT have an attribute {}base with a value of xs:anyType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-6"><sch:title>No base type of xs:anySimpleType</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:anySimpleType')"
+     >Rule 9-6: A schema component MUST NOT have an attribute {}base with a value of xs:anySimpleType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-7"><sch:title>No base type of xs:NOTATION</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:NOTATION')"
+     >Rule 9-7: A schema component MUST NOT have an attribute {}base with a value of xs:NOTATION.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-8"><sch:title>No base type of xs:ENTITY</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:ENTITY')"
+     >Rule 9-8: A schema component MUST NOT have an attribute {}base with a value of xs:ENTITY.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-9"><sch:title>No base type of xs:ENTITIES</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:ENTITIES')"
+     >Rule 9-9: A schema component MUST NOT have an attribute {}base with a value of xs:ENTITIES.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-10"><sch:title>Simple type definition is top-level</sch:title>
+ <sch:rule context="xs:simpleType">
+   <sch:assert test="exists(parent::xs:schema)"
+     >Rule 9-10: A simple type definition MUST be top-level.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-12"><sch:title>Simple type has data definition</sch:title>
+ <sch:rule context="xs:simpleType">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-12: A simple type MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-14"><sch:title>Enumeration has data definition</sch:title>
+ <sch:rule context="xs:enumeration">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-14: An enumeration facet MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-15"><sch:title>No list item type of xs:ID</sch:title>
+ <sch:rule context="xs:*[exists(@itemType)]">
+   <sch:assert test="resolve-QName(@itemType, .) != xs:QName('xs:ID')"
+     >Rule 9-15: A schema component MUST NOT have an attribute {}itemType with a value of xs:ID.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-16"><sch:title>No list item type of xs:IDREF</sch:title>
+ <sch:rule context="xs:*[exists(@itemType)]">
+   <sch:assert test="resolve-QName(@itemType, .) != xs:QName('xs:IDREF')"
+     >Rule 9-16: A schema component MUST NOT have an attribute {}itemType with a value of xs:IDREF.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-17"><sch:title>No list item type of xs:anySimpleType</sch:title>
+ <sch:rule context="xs:*[exists(@itemType)]">
+   <sch:assert test="resolve-QName(@itemType, .) != xs:QName('xs:anySimpleType')"
+     >Rule 9-17: A schema component MUST NOT have an attribute {}itemType with a value of xs:anySimpleType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-18"><sch:title>No list item type of xs:ENTITY</sch:title>
+ <sch:rule context="xs:*[exists(@itemType)]">
+   <sch:assert test="resolve-QName(@itemType, .) != xs:QName('xs:ENTITY')"
+     >Rule 9-18: A schema component MUST NOT have an attribute {}itemType with a value of xs:ENTITY.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-19"><sch:title>No union member types of xs:ID</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:ID')"
+     >Rule 9-19: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:ID.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-20"><sch:title>No union member types of xs:IDREF</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:IDREF')"
+     >Rule 9-20: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:IDREF.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-21"><sch:title>No union member types of xs:IDREFS</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:IDREFS')"
+     >Rule 9-21: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:IDREFS.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-22"><sch:title>No union member types of xs:anySimpleType</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:anySimpleType')"
+     >Rule 9-22: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:anySimpleType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-23"><sch:title>No union member types of xs:ENTITY</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:ENTITY')"
+     >Rule 9-23: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:ENTITY.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-24"><sch:title>No union member types of xs:ENTITIES</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:ENTITIES')"
+     >Rule 9-24: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:ENTITIES.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-25"><sch:title>Complex type definition is top-level</sch:title>
+ <sch:rule context="xs:complexType">
+   <sch:assert test="exists(parent::xs:schema)"
+     >Rule 9-25: A complex type definition MUST be top-level.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-26"><sch:title>Complex type has data definition</sch:title>
+ <sch:rule context="xs:complexType">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-26: A complex type MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-27"><sch:title>No mixed content on complex type</sch:title>
+ <sch:rule context="xs:complexType[exists(@mixed)]">
+   <sch:assert test="xs:boolean(@mixed) = false()"
+     >Rule 9-27: A complex type definition MUST NOT have mixed content.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-28"><sch:title>No mixed content on complex content</sch:title>
+ <sch:rule context="xs:complexContent[exists(@mixed)]">
+   <sch:assert test="xs:boolean(@mixed) = false()"
+     >Rule 9-28: A complex type definition with complex content MUST NOT have mixed content.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-29"><sch:title>Complex type content is explicitly simple or complex</sch:title>
+ <sch:rule context="xs:complexType">
+   <sch:assert test="exists(xs:simpleContent) or exists(xs:complexContent)"
+     >Rule 9-29: An element xs:complexType MUST have a child element xs:simpleContent or xs:complexContent.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-31"><sch:title>Base type of complex type with complex content must have complex content</sch:title>
+ <sch:rule context="xs:complexType/xs:complexContent/xs:*[
+                      (self::xs:extension or self::xs:restriction)
+                      and (some $base-qname in resolve-QName(@base, .) satisfies
+                             namespace-uri-from-QName($base-qname) = nf:get-target-namespace(.))]">
+   <sch:assert test="some $base-type in nf:resolve-type(., resolve-QName(@base, .)) satisfies
+                       empty($base-type/self::xs:complexType/xs:simpleContent)">Rule 9-31: 
+    The base type of complex type that has complex content MUST be a complex type with complex content.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-36"><sch:title>Element declaration is top-level</sch:title>
+ <sch:rule context="xs:element[exists(@name)]">
+   <sch:assert test="exists(parent::xs:schema)">Rule 9-36: 
+     An element declaration MUST be top-level.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-37"><sch:title>Element declaration has data definition</sch:title>
+ <sch:rule context="xs:element[exists(@name)]">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0">Rule 9-37: 
+     An element declaration MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-38"><sch:title>Untyped element is abstract</sch:title>
+ <sch:rule context="xs:schema/xs:element[empty(@type)]">
+   <sch:assert test="exists(@abstract)
+                     and xs:boolean(@abstract) = true()">Rule 9-38: 
+     A top-level element declaration that does not set the {type definition} property via the attribute "type" MUST have the {abstract} property with a value of "true".</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-39"><sch:title>Element of type xs:anySimpleType is abstract</sch:title>
+ <sch:rule context="xs:element[exists(@type)
+                               and resolve-QName(@type, .) = xs:QName('xs:anySimpleType')]">
+   <sch:assert test="exists(@abstract)
+                     and xs:boolean(@abstract) = true()">Rule 9-39: 
+               An element declaration that has a type xs:anySimpleType MUST have the {abstract} property with a value of "true".</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-41"><sch:title>Element type not in the XML namespace</sch:title>
+ <sch:rule context="xs:element[exists(@type)]">
+   <sch:assert test="namespace-uri-from-QName(resolve-QName(@type, .)) != 'http://www.w3.org/XML/1998/namespace'">Rule 9-41: 
+     An element type MUST NOT have a namespace name that is in the XML namespace.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-42"><sch:title>Element type is not simple type</sch:title>
+ <sch:rule context="xs:element[@type]">
+   <sch:assert test="every $type-qname in resolve-QName(@type, .),
+                           $type-ns in namespace-uri-from-QName($type-qname),
+                           $type-local-name in local-name-from-QName($type-qname) satisfies (
+                       $type-qname = xs:QName('xs:anySimpleType')
+                       or (($type-ns = nf:get-target-namespace(.)
+                            or exists(nf:get-document-element(.)/xs:import[
+                                        xs:anyURI(@namespace) = $type-ns
+                                        and empty(@appinfo:externalImportIndicator)]))
+                           and not(ends-with($type-local-name, 'SimpleType'))))">Rule 9-42: 
+     An element type that is not xs:anySimpleType MUST NOT be a simple type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-45"><sch:title>No element default value</sch:title>
+ <sch:rule context="xs:element">
+   <sch:assert test="empty(@default)"
+     >Rule 9-45: An element xs:element MUST NOT have an attribute {}default.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-46"><sch:title>No element fixed value</sch:title>
+ <sch:rule context="xs:element">
+   <sch:assert test="empty(@fixed)"
+     >Rule 9-46: An element xs:element MUST NOT have an attribute {}fixed.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-48"><sch:title>Attribute declaration is top-level</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:assert test="exists(parent::xs:schema)"
+     >Rule 9-48: An attribute declaration MUST be top-level.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-49"><sch:title>Attribute declaration has data definition</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-49: An attribute declaration MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-50"><sch:title>Attribute declaration has type</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:assert test="exists(@type)"
+     >Rule 9-50: A top-level attribute declaration MUST have a type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-51"><sch:title>No attribute type of xs:ID</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:ID')"
+     >Rule 9-51: A schema component MUST NOT have an attribute {}type with a value of xs:ID.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-52"><sch:title>No attribute type of xs:IDREF</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:IDREF')"
+     >Rule 9-52: A schema component MUST NOT have an attribute {}type with a value of xs:IDREF.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-53"><sch:title>No attribute type of xs:IDREFS</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:IDREFS')"
+     >Rule 9-53: A schema component MUST NOT have an attribute {}type with a value of xs:IDREFS.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-54"><sch:title>No attribute type of xs:ENTITY</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:ENTITY')"
+     >Rule 9-54: A schema component MUST NOT have an attribute {}type with a value of xs:ENTITY.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-55"><sch:title>No attribute type of xs:ENTITIES</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:ENTITIES')"
+     >Rule 9-55: A schema component MUST NOT have an attribute {}type with a value of xs:ENTITIES.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-56"><sch:title>No attribute type of xs:anySimpleType</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:anySimpleType')"
+     >Rule 9-56: A schema component MUST NOT have an attribute {}type with a value of xs:anySimpleType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-57"><sch:title>No attribute default values</sch:title>
+ <sch:rule context="xs:attribute">
+   <sch:assert test="empty(@default)"
+     >Rule 9-57: An element xs:attribute MUST NOT have an attribute {}default.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-58"><sch:title>No fixed values for optional attributes</sch:title>
+ <sch:rule context="xs:attribute[exists(@ref) and @use eq 'required']">
+   <sch:report test="false()" role="warning">This rule does not constrain attribute uses that are required</sch:report>
+ </sch:rule>
+ <sch:rule context="xs:attribute">
+   <sch:assert test="empty(@fixed)"
+     >Rule 9-58: An element xs:attribute that is not a required attribute use MUST NOT have an attribute {}fixed.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-59"><sch:title>No use of element xs:notation</sch:title>
+ <sch:rule context="xs:notation">
+   <sch:assert test="false()"
+     >Rule 9-59: The schema MUST NOT contain the element xs:notation.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-61"><sch:title>No xs:all</sch:title>
+ <sch:rule context="xs:all">
+   <sch:assert test="false()"
+     >Rule 9-61: The schema MUST NOT contain the element xs:all</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-63"><sch:title>xs:sequence must be child of xs:extension or xs:restriction</sch:title>
+ <sch:rule context="xs:sequence">
+   <sch:assert test="exists(parent::xs:extension) or exists(parent::xs:restriction)"
+     >Rule 9-63: An element xs:sequence MUST be a child of element xs:extension or xs:restriction.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-65"><sch:title>xs:choice must be child of xs:sequence</sch:title>
+ <sch:rule context="xs:choice">
+   <sch:assert test="exists(parent::xs:sequence)"
+     >Rule 9-65: An element xs:choice MUST be a child of element xs:sequence.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-66"><sch:title>Sequence has minimum cardinality 1</sch:title>
+ <sch:rule context="xs:sequence">
+   <sch:assert test="empty(@minOccurs) or xs:integer(@minOccurs) = 1"
+     >Rule 9-66: An element xs:sequence MUST either not have the attribute {}minOccurs, or that attribute MUST have a value of 1.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-67"><sch:title>Sequence has maximum cardinality 1</sch:title>
+ <sch:rule context="xs:sequence">
+   <sch:assert test="empty(@maxOccurs) or (@maxOccurs instance of xs:integer
+                                           and 1 = xs:integer(@maxOccurs))"
+     >Rule 9-67: An element xs:sequence MUST either not have the attribute {}maxOccurs, or that attribute MUST have a value of 1.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-68"><sch:title>Choice has minimum cardinality 1</sch:title>
+ <sch:rule context="xs:choice">
+   <sch:assert test="empty(@minOccurs) or 1 = xs:integer(@minOccurs)"
+     >Rule 9-68: An element xs:choice MUST either not have the attribute {}minOccurs, or that attribute MUST have a value of 1.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-69"><sch:title>Choice has maximum cardinality 1</sch:title>
+ <sch:rule context="xs:choice">
+   <sch:assert test="empty(@maxOccurs) or (@maxOccurs instance of xs:integer
+                                           and 1 = xs:integer(@maxOccurs))"
+     >Rule 9-69: An element xs:choice MUST either not have the attribute {}maxOccurs, or that attribute MUST have a value of 1.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-72"><sch:title>No use of xs:unique</sch:title>
+ <sch:rule context="xs:unique">
+   <sch:assert test="false()"
+     >Rule 9-72: The schema MUST NOT contain the element xs:unique.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-73"><sch:title>No use of xs:key</sch:title>
+ <sch:rule context="xs:key">
+   <sch:assert test="false()"
+     >Rule 9-73: The schema MUST NOT contain the element xs:key.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-74"><sch:title>No use of xs:keyref</sch:title>
+ <sch:rule context="xs:keyref">
+   <sch:assert test="false()"
+     >Rule 9-74: The schema MUST NOT contain the element xs:keyref.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-75"><sch:title>No use of xs:group</sch:title>
+ <sch:rule context="xs:group">
+   <sch:assert test="false()"
+     >Rule 9-75: The schema MUST NOT contain the element xs:group.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-76"><sch:title>No definition of attribute groups</sch:title>
+ <sch:rule context="xs:attributeGroup[@name]">
+   <sch:assert test="false()"
+     >Rule 9-76: The schema MUST NOT contain an attribute group definition schema component.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-77"><sch:title>Comment is not recommended</sch:title>
+ <sch:rule context="node()[comment()]">
+   <sch:report test="true()" role="warning"
+     >An XML Comment is not an XML Schema annotation component; an XML comment SHOULD NOT appear in the schema.</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-78"><sch:title>Documentation element has no element children</sch:title>
+ <sch:rule context="xs:documentation/node()">
+   <sch:assert test="self::text() or self::comment()"
+     >Rule 9-78: A child of element xs:documentation MUST be text or an XML comment.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-79"><sch:title>xs:appinfo children are comments, elements, or whitespace</sch:title>
+ <sch:rule context="xs:appinfo/node()">
+   <sch:assert test="self::comment()
+                     or self::element()
+                     or self::text()[string-length(normalize-space(.)) = 0]"
+     >Rule 9-79: A child of element xs:appinfo MUST be an element, a comment, or whitespace text.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-80"><sch:title>Appinfo child elements have namespaces</sch:title>
+ <sch:rule context="xs:appinfo/*">
+   <sch:assert test="namespace-uri() != xs:anyURI('')"
+     >Rule 9-80: An element that is a child of xs:appinfo MUST have a namespace name.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-81"><sch:title>Appinfo descendants are not XML Schema elements</sch:title>
+ <sch:rule context="xs:appinfo//xs:*">
+   <sch:assert test="false()"
+     >Rule 9-81: An element with a namespace name of xs: MUST NOT have an ancestor element xs:appinfo.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-82"><sch:title>Schema has data definition</sch:title>
+ <sch:rule context="xs:schema">
+   <sch:assert test="some $definition in (xs:annotation/xs:documentation)[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-82: An element xs:schema MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-83"><sch:title>Schema document defines target namespace</sch:title>
+ <sch:rule context="xs:schema">
+   <sch:assert test="exists(@targetNamespace)"
+     >Rule 9-83: The schema MUST define a target namespace.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-85"><sch:title>Schema has version</sch:title>
+ <sch:rule context="xs:schema">
+   <sch:assert test="some $version in @version satisfies
+                     string-length(normalize-space(@version)) &gt; 0"
+       >Rule 9-85: An element xs:schema MUST have an attribute {}version that MUST NOT be empty.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-88"><sch:title>No use of xs:redefine</sch:title>
+ <sch:rule context="xs:redefine">
+   <sch:assert test="false()"
+     >Rule 9-88: The schema MUST NOT contain the element xs:redefine.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-89"><sch:title>No use of xs:include</sch:title>
+ <sch:rule context="xs:include">
+   <sch:assert test="false()"
+     >Rule 9-89: The schema MUST NOT contain the element xs:include.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-90"><sch:title>xs:import must have namespace</sch:title>
+ <sch:rule context="xs:import">
+   <sch:assert test="exists(@namespace)"
+     >Rule 9-90: An element xs:import MUST have an attribute {}namespace.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-92"><sch:title>Namespace referenced by attribute type is imported</sch:title>
+ <sch:rule context="xs:*[@type]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@type, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or $namespace = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace])"
+               >Rule 9-92: The namespace of a type referenced by @type MUST be the target namespace, the XML Schema namespace, or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-93"><sch:title>Namespace referenced by attribute base is imported</sch:title>
+ <sch:rule context="xs:*[@base]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@base, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or $namespace = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace])"
+               >Rule 9-93: The namespace of a type referenced by @base MUST be the target namespace, the XML Schema namespace, or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-94"><sch:title>Namespace referenced by attribute itemType is imported</sch:title>
+ <sch:rule context="xs:*[@itemType]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@itemType, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or $namespace = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace])"
+               >Rule 9-94: The namespace of a type referenced by @itemType MUST be the target namespace, the XML Schema namespace, or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-95"><sch:title>Namespaces referenced by attribute memberTypes is imported</sch:title>
+ <sch:rule context="xs:*[@memberTypes]">
+   <sch:assert test="every $type in tokenize(normalize-space(@memberTypes), ' '),
+                           $namespace in namespace-uri-from-QName(resolve-QName($type, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or $namespace = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace])"
+               >Rule 9-95: The namespace of a type referenced by @memberTypes MUST be the target namespace, the XML Schema namespace, or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-96"><sch:title>Namespace referenced by attribute ref is imported</sch:title>
+ <sch:rule context="xs:*[@ref]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies
+                       $namespace = nf:get-target-namespace(.)
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace]"
+               >Rule 9-96: The namespace of a component referenced by @ref MUST be the target namespace or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-97"><sch:title>Namespace referenced by attribute substitutionGroup is imported</sch:title>
+ <sch:rule context="xs:*[@substitutionGroup]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@substitutionGroup, .)) satisfies
+                       $namespace = nf:get-target-namespace(.)
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace]"
+               >Rule 9-97: The namespace of a component referenced by @substitutionGroup MUST be the target namespace or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-2"><sch:title>Object type with complex content is derived from structures:ObjectType</sch:title>
+ <sch:rule context="xs:complexType[exists(xs:complexContent)
+                                   and not(ends-with(@name, 'AssociationType')
+                                       or ends-with(@name, 'MetadataType')
+                                       or ends-with(@name, 'AugmentationType'))]">
+   <sch:assert test="
+       every $derivation-method in (xs:complexContent/xs:extension, xs:complexContent/xs:restriction),
+             $base in $derivation-method/@base,
+             $base-qname in resolve-QName($base, $derivation-method),
+             $base-local-name in local-name-from-QName($base-qname) satisfies (
+         $base-qname = xs:QName('structures:ObjectType')
+         or not(ends-with($base-local-name, 'AssociationType')
+                or ends-with($base-local-name, 'AugmentationType')))"
+     >Rule 10-2: An object type with complex content MUST be derived from structures:ObjectType or from another object type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-7"><sch:title>Import of external namespace has data definition</sch:title>
+ <sch:rule context="xs:import[@appinfo:externalImportIndicator]">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 10-7: An element xs:import that is annotated as importing an external schema document MUST be a documented component.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-9"><sch:title>Structure of external adapter type definition follows pattern</sch:title>
+ <sch:rule context="xs:complexType[@appinfo:externalAdapterTypeIndicator]">
+   <sch:assert test="xs:complexContent/xs:extension[
+                       resolve-QName(@base, .) = xs:QName('structures:ObjectType')
+                     ]/xs:sequence"
+     >Rule 10-9: An external adapter type definition MUST be a complex type definition with complex content that extends structures:ObjectType, and that uses xs:sequence as its top-level compositor.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-10"><sch:title>Element use from external adapter type defined by external schema documents</sch:title>
+ <sch:rule context="xs:element[@ref
+                               and exists(ancestor::xs:complexType[exists(@appinfo:externalAdapterTypeIndicator)])]">
+   <sch:assert test="some $ref-namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies
+                       nf:get-document-element(.)/xs:import[
+                         $ref-namespace = xs:anyURI(@namespace)
+                         and @appinfo:externalImportIndicator]"
+     >Rule 10-10: An element reference that appears within an external adapter type MUST have a target namespace that is imported as external.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-11"><sch:title>External adapter type not a base type</sch:title>
+ <sch:rule context="xs:*[(self::xs:extension or self::xs:restriction)
+                         and (some $base-qname in resolve-QName(@base, .),
+                                   $base-namespace in namespace-uri-from-QName($base-qname) satisfies
+                                nf:get-target-namespace(.) = $base-namespace)]">
+   <sch:assert test="nf:resolve-type(., resolve-QName(@base, .))[
+                       empty(@appinfo:externalAdapterTypeIndicator)]"
+      >Rule 10-11: An external adapter type definition MUST NOT be a base type definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-14"><sch:title>External attribute use has data definition</sch:title>
+ <sch:rule context="xs:attribute[some $ref-namespace in namespace-uri-from-QName(resolve-QName(@ref, .)),
+                                      $import in ancestor::xs:schema[1]/xs:import satisfies (
+                                   xs:anyURI($import/@namespace) = $ref-namespace
+                                   and exists(@appinfo:externalImportIndicator))]">
+   <sch:assert test="some $documentation in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($documentation))) &gt; 0"
+     >Rule 10-14: An external attribute use MUST be a documented component with a non-empty data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-16"><sch:title>External element use has data definition</sch:title>
+ <sch:rule context="xs:element[
+     some $ref-namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies
+       nf:get-document-element(.)/self::xs:schema//xs:import[
+         xs:anyURI(@namespace) = $ref-namespace
+         and @appinfo:externalImportIndicator]]">
+   <sch:assert test="some $documentation in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($documentation))) &gt; 0"
+     >Rule 10-16: An external attribute use MUST be a documented component with a non-empty data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-17"><sch:title>Name of code type ends in "CodeType"</sch:title>
+ <sch:rule context="xs:complexType[exists(xs:simpleContent[
+                      exists(xs:*[local-name() = ('extension', 'restriction')
+                                  and (ends-with(@base, 'CodeSimpleType')
+                                  or ends-with(@base, 'CodeType'))])])]">
+   <sch:report role="warning"
+       test="not(ends-with(@name, 'CodeType'))"
+     >A complex type definition with a {base type definition} of a code type or code simple type SHOULD have a {name} that ends in 'CodeType'.</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-19"><sch:title>Element of code type has code representation term</sch:title>
+ <sch:rule context="xs:element[exists(@name) and exists(@type) and ends-with(@type, 'CodeType')]">
+   <sch:report role="warning"
+       test="not(ends-with(@name, 'Code'))"
+     >An element with a type that is a code type SHOULD have a name with representation term "Code"</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-20"><sch:title>Proxy type has designated structure</sch:title>
+ <sch:rule context="xs:complexType[some $name in @name,
+                                   $extension in xs:simpleContent/xs:extension,
+                                   $base-qname in resolve-QName($extension/@base, $extension) satisfies
+                                   $base-qname = QName('http://www.w3.org/2001/XMLSchema', $name)]">
+   <sch:assert test="xs:simpleContent[
+                       xs:extension[
+                         empty(xs:attribute)
+                         and count(xs:attributeGroup) = 1
+                         and xs:attributeGroup[
+                               resolve-QName(@ref, .) = xs:QName('structures:SimpleObjectAttributeGroup')]]]"
+     >Rule 10-20: A proxy type MUST have the designated structure. It MUST use xs:extension. It MUST NOT use xs:attribute. It MUST include exactly one xs:attributeGroup reference, which must be to structures:SimpleObjectAttributeGroup.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-21"><sch:title>Association type derived from structures:AssociationType</sch:title>
+ <sch:rule context="xs:complexType">
+   <sch:let name="is-association-type" value="exists(@name[ends-with(., 'AssociationType')])"/>
+   <sch:let name="has-association-base-type" value="
+     exists(xs:complexContent[
+       exists(xs:*[local-name() = ('extension', 'restriction')
+                   and exists(@base[ends-with(., 'AssociationType')])])])"/>
+   <sch:assert test="$is-association-type = $has-association-base-type"
+     >Rule 10-21: A type MUST have an association type name if and only if it is derived from an association type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-22"><sch:title>Association element type is an association type</sch:title>
+ <sch:rule context="xs:element[exists(@name)]">
+   <sch:assert test="exists(@type[ends-with(., 'AssociationType')])
+                     = exists(@name[ends-with(., 'Association')])"
+     >Rule 10-22: An element MUST have a name that ends in 'Association' if and only if it has a type that is an association type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-24"><sch:title>Augmentable type has at most one augmentation point element</sch:title>
+ <sch:rule context="xs:complexType[
+                      @name[not(ends-with(., 'MetadataType'))
+                            and not(ends-with(., 'AugmentationType'))]
+                      and empty(@appinfo:externalAdapterTypeIndicator)
+                      and xs:complexContent]">
+   <sch:let name="augmentation-point-qname"
+            value="QName(string(nf:get-target-namespace(.)),
+                         replace(./@name, 'Type$', 'AugmentationPoint'))"/>
+   <sch:assert test="count(xs:complexContent/xs:extension/xs:sequence/xs:element[
+                             @ref[resolve-QName(., ..) = $augmentation-point-qname]]) le 1"
+     >Rule 10-24: An augmentable type MUST contain no more than one element use of its corresponding augmentation point element.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-25"><sch:title>Augmentation point element corresponds to its base type</sch:title>
+ <sch:rule context="xs:element[exists(@name[
+                                matches(., 'AugmentationPoint$')])]">
+   <sch:let name="element-name" value="@name"/>
+   <sch:assert test="exists(
+                       parent::xs:schema/xs:complexType[
+                         @name = replace($element-name, 'AugmentationPoint$', 'Type')
+                         and exists(@name[
+                                 not(ends-with(., 'MetadataType'))
+                                 and not(ends-with(., 'AugmentationType'))])
+                               and empty(@appinfo:externalAdapterTypeIndicator)
+                               and exists(child::xs:complexContent)])"
+     >Rule 10-25: A schema document containing an element declaration for an augmentation point element MUST also contain a type definition for its base type, a corresponding augmentable type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-26"><sch:title>An augmentation point element has no type</sch:title>
+ <sch:rule context="xs:element[exists(@name[
+                                matches(., 'AugmentationPoint$')])]">
+   <sch:assert test="empty(@type)"
+       >Rule 10-26: An augmentation point element MUST have no type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-27"><sch:title>An augmentation point element has no substitution group</sch:title>
+ <sch:rule context="xs:element[exists(@name[
+                                matches(., 'AugmentationPoint$')])]">
+   <sch:assert test="empty(@substitutionGroup)"
+       >Rule 10-27: An augmentation point element MUST have no substitution group.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-28"><sch:title>Augmentation point element is only referenced by its base type</sch:title>
+ <sch:rule context="xs:complexType//xs:element[exists(@ref[
+                      matches(local-name-from-QName(resolve-QName(., ..)), 'AugmentationPoint$')]) ]">
+   <sch:assert test="QName(string(nf:get-target-namespace(ancestor::xs:complexType[1])), ancestor::xs:complexType[1]/@name)
+                     = QName(string(namespace-uri-from-QName(resolve-QName(@ref, .))),
+                         replace(local-name-from-QName(resolve-QName(@ref, .)), 'AugmentationPoint$', 'Type'))"
+     >Rule 10-28: An augmentation point element MUST only be referenced by its base type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-31"><sch:title>Augmentation point element use must be last element in its base type</sch:title>
+ <sch:rule context="xs:complexType//xs:element[exists(@ref[
+                          matches(local-name-from-QName(resolve-QName(., ..)), 'AugmentationPoint$')]) ]">
+   <sch:assert test="empty(following-sibling::*)"
+      >Rule 10-31: An augmentation point element particle MUST be the last element occurrence in its content model.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-34"><sch:title>Schema component with name ending in "AugmentationType" is an augmentation type</sch:title>
+ <sch:rule context="xs:*[ends-with(@name, 'AugmentationType')]">
+   <sch:assert test="self::xs:complexType/xs:complexContent/xs:*[
+                       (self::xs:extension or self::xs:restriction)
+                       and ends-with(@base, 'AugmentationType')]"
+      >Rule 10-34: An augmentation type definition schema component with {name} ending in 'AugmentationType' MUST be an augmentation type definition that is a complex type definition with complex content that extends or restricts an augmentation type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-35"><sch:title>Type derived from structures:AugmentationType is an augmentation type</sch:title>
+ <sch:rule context="xs:*[(self::xs:restriction or self::xs:extension)
+                         and ends-with(@base, 'AugmentationType')]">
+   <sch:assert test="ancestor::xs:complexType[ends-with(@name, 'AugmentationType')]"
+               >Rule 10-35: A type definition derived from an augmentation type MUST be an augmentation type definition</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-36"><sch:title>Augmentation element type is an augmentation type</sch:title>
+ <sch:rule context="xs:element[exists(@name)]">
+   <sch:assert test="exists(@type[ends-with(., 'AugmentationType')])
+                     = exists(@name[ends-with(., 'Augmentation')])"
+     >Rule 10-36: An element declaration MUST have a name that ends in "Augmentation" if and only if it has a type that is an augmentation type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-42"><sch:title>Name of element that ends in "Representation" is abstract</sch:title>
+ <sch:rule context="xs:element[@name[ends-with(., 'Representation')]]">
+   <sch:report role="warning"
+       test="empty(@abstract) or xs:boolean(@abstract) = false()"
+     >An element declaration with a name that ends in 'Representation' SHOULD have the {abstract} property with a value of "true".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-45"><sch:title>Schema component name has xml:lang</sch:title>
+ <sch:rule context="xs:*[exists(@name)]">
+   <sch:let name="xml-lang-attribute" value="ancestor-or-self::*[exists(@xml:lang)][1]/@xml:lang"/>
+   <sch:assert test="exists($xml-lang-attribute)
+                     and string-length(normalize-space($xml-lang-attribute)) gt 0"
+               >Rule 10-45: The name of an XML Schema component defined by the schema MUST be in the scope of an occurrence of attribute xml:lang that has a value that is not empty.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-46"><sch:title>Schema component names have only specific characters</sch:title>
+ <sch:rule context="xs:*[exists(@name)]">
+   <sch:assert test="matches(@name, '^[A-Za-z0-9\-_\.]*$')"
+     >Rule 10-46: The name of an XML Schema component defined by the schema must be composed of only the characters uppercase 'A' through 'Z', lowercase 'a' through 'z', numbers '0' through '9', underscore, hyphen, and period.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-49"><sch:title>Attribute name begins with lower case letter</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:assert test="matches(@name, '^[a-z]')"
+     >Rule 10-49: Within the schema, any attribute declaration MUST have a name that begins with a lowercase letter
+     ('a'-'z').</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-50"><sch:title>Name of schema component other than attribute and proxy type begins with upper case letter</sch:title>
+ <sch:rule context="xs:attribute">
+   <sch:report test="false()" role="warning">This rule does not apply to an attribute.</sch:report>
+ </sch:rule>
+ <sch:rule context="xs:complexType[some $name in @name,
+                                   $extension in xs:simpleContent/xs:extension,
+                                   $base-qname in resolve-QName($extension/@base, $extension) satisfies
+                                   $base-qname = QName('http://www.w3.org/2001/XMLSchema', $name)]">
+   <sch:report test="false()" role="warning">This rule does not apply to a proxy types.</sch:report>
+ </sch:rule>
+ <sch:rule context="xs:*[exists(@name)]">
+   <sch:assert test="matches(@name, '^[A-Z]')"
+     >Rule 10-50: Within the schema, an XML Schema component that is not an attribute declaration or proxy type MUST have a name that begins with an upper-case letter ('A'-'Z').</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-69"><sch:title>Deprecated annotates schema component</sch:title>
+ <sch:rule context="*[exists(@appinfo:deprecated)]">
+   <sch:assert test="namespace-uri-from-QName(node-name(.)) = xs:anyURI('http://www.w3.org/2001/XMLSchema')"
+           >Rule 10-69: The attribute appinfo:deprecated MUST be owned by an element with a namespace name http://www.w3.org/2001/XMLSchema.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-70"><sch:title>External import indicator annotates import</sch:title>
+ <sch:rule context="*[exists(@appinfo:externalImportIndicator)]">
+   <sch:assert test="exists(self::xs:import)"
+       >Rule 10-70: The attribute {https://docs.oasis-open.org/niemopen/ns/model/appinfo/6.0/}externalImportIndicator MUST be owned by an element xs:import.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-71"><sch:title>External adapter type indicator annotates complex type</sch:title>
+ <sch:rule context="*[exists(@appinfo:externalAdapterTypeIndicator)]">
+   <sch:assert test="exists(self::xs:complexType)"
+           >Rule 10-71: The attribute appinfo:externalAdapterTypeIndicator MUST be owned by an element xs:complexType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-76"><sch:title>appinfo:LocalTerm annotates schema</sch:title>
+ <sch:rule context="appinfo:LocalTerm">
+   <sch:assert test="parent::xs:appinfo[parent::xs:annotation[parent::xs:schema]]"
+     >Rule 10-76: The element appinfo:LocalTerm MUST be application information on an element xs:schema.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-77"><sch:title>appinfo:LocalTerm has literal or definition</sch:title>
+ <sch:rule context="appinfo:LocalTerm">
+   <sch:assert test="exists(@literal) or exists(@definition)"
+           >Rule 10-77: The element {https://docs.oasis-open.org/niemopen/ns/model/appinfo/6.0/}LocalTerm MUST have a literal or definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-1"><sch:title>Name of type ends in "Type"</sch:title>
+ <sch:rule context="xs:complexType[some $name in @name,
+                                   $extension in xs:simpleContent/xs:extension,
+                                   $base-qname in resolve-QName($extension/@base, $extension) satisfies
+                                   $base-qname = QName('http://www.w3.org/2001/XMLSchema', $name)]">
+   <sch:report test="false()" role="warning">The name of a proxy type does not end in "Type".</sch:report>
+ </sch:rule>
+ <sch:rule context="xs:*[(self::xs:simpleType or self::xs:complexType) and exists(@name)]">
+   <sch:assert test="ends-with(@name, 'Type')"
+     >Rule 11-1: A type definition schema component that does not define a proxy type MUST have a name that ends in "Type".</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-2"><sch:title>Only types have name ending in "Type" or "SimpleType"</sch:title>
+ <sch:rule context="xs:*[exists(@name) and ends-with(@name, 'SimpleType')]">
+   <sch:assert test="local-name() = 'simpleType'"
+               >Rule 11-2: A schema component with a name that ends in 'SimpleType' MUST be a simple type definition.</sch:assert>
+ </sch:rule>
+ <sch:rule context="xs:*[exists(@name) and ends-with(@name, 'Type')]">
+   <sch:assert test="local-name() = 'complexType'"
+               >A schema component with a name that ends in 'Type' and does not end in 'SimpleType' MUST be a complex type definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-3"><sch:title>Base type definition defined by conformant schema</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="some $base-namespace in namespace-uri-from-QName(resolve-QName(@base, .)) satisfies (
+                       $base-namespace = (nf:get-target-namespace(.), xs:anyURI('http://www.w3.org/2001/XMLSchema'))
+                       or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                                                  and $base-namespace = xs:anyURI(@namespace)
+                                                                  and empty(@appinfo:externalImportIndicator)]))"
+     >Rule 11-3: The {base type definition} of a type definition MUST have the target namespace or the XML Schema namespace or a namespace that is imported as conformant.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-4"><sch:title>Name of simple type ends in "SimpleType"</sch:title>
+ <sch:rule context="xs:simpleType[@name]">
+   <sch:assert test="ends-with(@name, 'SimpleType')"
+     >Rule 11-4: A simple type definition schema component MUST have a name that ends in "SimpleType".</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-6"><sch:title>List item type defined by conformant schemas</sch:title>
+ <sch:rule context="xs:list[exists(@itemType)]">
+   <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@itemType, .))"/>
+   <sch:assert test="$namespace = (nf:get-target-namespace(.), xs:anyURI('http://www.w3.org/2001/XMLSchema'))
+                     or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                   and $namespace = xs:anyURI(@namespace)
+                                   and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-6: The item type of a list simple type definition MUST have a target namespace equal to the target namespace of the XML Schema document within which it is defined, or a namespace that is imported as conformant by the schema document within which it is defined.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-7"><sch:title>Union member types defined by conformant schemas</sch:title>
+ <sch:rule context="xs:union[exists(@memberTypes)]">
+   <sch:assert test="every $qname in tokenize(normalize-space(@memberTypes), ' '),
+                           $namespace in namespace-uri-from-QName(resolve-QName($qname, .))
+                     satisfies ($namespace = nf:get-target-namespace(.)
+                                or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                          and $namespace = xs:anyURI(@namespace)
+                                          and empty(@appinfo:externalImportIndicator)]))"
+               >Rule 11-7: Every member type of a union simple type definition MUST have a target namespace that is equal to either the target namespace of the XML Schema document within which it is defined or a namespace that is imported as conformant by the schema document within which it is defined.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-8"><sch:title>Name of a code simple type ends in "CodeSimpleType"</sch:title>
+ <sch:rule context="xs:simpleType[exists(@name)
+     and (xs:restriction/xs:enumeration
+          or xs:restriction[ends-with(local-name-from-QName(resolve-QName(@base, .)), 'CodeSimpleType')])]">
+   <sch:report test="not(ends-with(@name, 'CodeSimpleType'))" role="warning"
+     >A simple type definition schema component that has an enumeration facet or that is derived from a code simple type SHOULD have a name that ends in "CodeSimpleType".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-10"><sch:title>Attribute of code simple type has code representation term</sch:title>
+ <sch:rule context="xs:attribute[exists(@name) and exists(@type) and ends-with(@type, 'CodeSimpleType')]">
+   <sch:report test="not(ends-with(@name, 'Code'))" role="warning"
+     >An attribute with a type that is a code simple type SHOULD have a name with representation term "Code"</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-11"><sch:title>Complex type with simple content has structures:SimpleObjectAttributeGroup</sch:title>
+ <sch:rule context="xs:simpleContent/xs:extension[
+     some $base-qname in resolve-QName(@base, .) satisfies
+       namespace-uri-from-QName($base-qname) = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+       or ends-with(local-name-from-QName($base-qname), 'SimpleType')]">
+   <sch:assert test="xs:attributeGroup[
+                       resolve-QName(@ref, .) = xs:QName('structures:SimpleObjectAttributeGroup')]"
+     >Rule 11-11: A complex type definition with simple content schema component with a derivation method of extension that has a base type definition that is a simple type MUST incorporate the attribute group {https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/}SimpleObjectAttributeGroup.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-12"><sch:title>Element type does not have a simple type name</sch:title>
+ <sch:rule context="xs:element[exists(@type)]">
+   <sch:assert test="not(ends-with(@type, 'SimpleType'))"
+               >Rule 11-12: The {type definition} of an element declaration MUST NOT have a {name} that ends in 'SimpleType'.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-13"><sch:title>Element type is from conformant namespace</sch:title>
+ <sch:rule context="xs:element[exists(@type)]">
+   <sch:assert test="for $type-qname in resolve-QName(@type, .),
+                         $type-namespace in namespace-uri-from-QName($type-qname) return
+                       $type-namespace = nf:get-target-namespace(.)
+                       or exists(nf:get-document-element(.)/xs:import[
+                                   xs:anyURI(@namespace) = $type-namespace
+                                   and empty(@appinfo:externalImportIndicator)])"
+               >Rule 11-13: The {type definition} of an element declaration MUST have a {target namespace} that is the target namespace, or one that is imported as conformant.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-14"><sch:title>Name of element that ends in "Abstract" is abstract</sch:title>
+ <sch:rule context="xs:element[@name]">
+   <sch:report role="warning"
+       test="not(exists(@abstract[xs:boolean(.) = true()])
+                 eq (ends-with(@name, 'Abstract')
+                     or ends-with(@name, 'AugmentationPoint')
+                     or ends-with(@name, 'Representation')))"
+     >An element declaration SHOULD have a name that ends in 'Abstract', 'AugmentationPoint', or 'Representation' if and only if it has the {abstract} property with a value of "true".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-15"><sch:title>Name of element declaration with simple content has representation term</sch:title>
+ <sch:rule context="xs:element[@name and @type
+                               and (some $type-qname in resolve-QName(@type, .) satisfies (
+                                      nf:get-target-namespace(.) = namespace-uri-from-QName($type-qname)
+                                      and nf:resolve-type(., $type-qname)/xs:simpleContent))]">
+   <sch:report role="warning"
+       test="every $representation-term
+             in ('Amount', 'BinaryObject', 'Graphic', 'Picture', 'Sound', 'Video', 'Code', 'DateTime', 'Date', 'Time', 'Duration', 'ID', 'URI', 'Indicator', 'Measure', 'Numeric', 'Value', 'Rate', 'Percent', 'Quantity', 'Text', 'Name', 'List')
+             satisfies not(ends-with(@name, $representation-term))"
+     >The name of an element declaration that is of simple content SHOULD use a representation term.</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-17"><sch:title>Element substitution group defined by conformant schema</sch:title>
+ <sch:rule context="xs:element[exists(@substitutionGroup)]">
+   <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@substitutionGroup, .))"/>
+   <sch:assert test="$namespace = nf:get-target-namespace(.)
+                     or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                   and $namespace = xs:anyURI(@namespace)
+                                   and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-17: An element substitution group MUST have either the target namespace or a namespace that is imported as conformant.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-18"><sch:title>Attribute type defined by conformant schema</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@type, .))"/>
+   <sch:assert test="$namespace = (nf:get-target-namespace(.), xs:anyURI('http://www.w3.org/2001/XMLSchema'))
+                     or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                   and $namespace = xs:anyURI(@namespace)
+                                   and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-18: The type of an attribute declaration MUST have the target namespace or the XML Schema namespace or a namespace that is imported as conformant.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-19"><sch:title>Attribute name uses representation term</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:report role="warning"
+       test="every $representation-term
+             in ('Amount', 'BinaryObject', 'Graphic', 'Picture', 'Sound', 'Video', 'Code', 'DateTime', 'Date', 'Time', 'Duration', 'ID', 'URI', 'Indicator', 'Measure', 'Numeric', 'Value', 'Rate', 'Percent', 'Quantity', 'Text', 'Name', 'List')
+             satisfies not(ends-with(@name, $representation-term))"
+     >An attribute name SHOULD end with a representation term.</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-21"><sch:title>Element reference defined by conformant schema</sch:title>
+ <sch:rule context="xs:element[exists(ancestor::xs:complexType[empty(@appinfo:externalAdapterTypeIndicator)]) and @ref]">
+   <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@ref, .))"/>
+   <sch:assert test="$namespace = nf:get-target-namespace(.)
+                     or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                   and $namespace = xs:anyURI(@namespace)
+                                   and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-21: An element reference MUST be to a component that has a namespace that is either the target namespace of the schema document in which it appears, or which is imported as conformant by that schema document.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-22"><sch:title>Referenced attribute defined by conformant schemas</sch:title>
+  <sch:rule context="xs:attribute[@ref]">
+     <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@ref, .))"/>
+     <sch:assert test="some $namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or ancestor::xs:schema[1]/xs:import[
+                            @namespace
+                            and $namespace = xs:anyURI(@namespace)
+                            and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-22: An attribute {}ref MUST have the target namespace or a namespace that is imported as conformant.     </sch:assert>
+  </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-23"><sch:title>Schema uses only known attribute groups</sch:title>
+  <sch:rule context="xs:attributeGroup[@ref]">
+    <sch:assert test="some $ref in resolve-QName(@ref, .) satisfies (
+                        $ref = xs:QName('structures:SimpleObjectAttributeGroup'))"
+      >Rule 11-23: An attribute group reference MUST be structures:SimpleObjectAttributeGroup</sch:assert>
+  </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-30"><sch:title>xs:documentation has xml:lang</sch:title>
+ <sch:rule context="xs:documentation">
+   <sch:let name="xml-lang-attribute" value="ancestor-or-self::*[exists(@xml:lang)][1]/@xml:lang"/>
+   <sch:assert test="exists($xml-lang-attribute)
+                     and string-length(normalize-space($xml-lang-attribute)) gt 0"
+               >Rule 11-30: An occurrence of xs:documentation within the schema MUST be in the scope of an occurrence of attribute xml:lang that has a value that is not empty.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-31"><sch:title>Standard opening phrase for augmentation point element data definition</sch:title>
+ <sch:rule context="xs:element[ends-with(@name, 'AugmentationPoint')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(starts-with(lower-case(normalize-space(.)), 'an augmentation point '))"
+     >The data definition for an augmentation point element SHOULD begin with standard opening phrase "An augmentation point...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-32"><sch:title>Standard opening phrase for augmentation element data definition</sch:title>
+ <sch:rule context="xs:element[ends-with(@name, 'Augmentation')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="every $phrase
+             in ('supplements ', 'additional information about ')
+             satisfies not(starts-with(lower-case(normalize-space(.)), $phrase))"
+     >The data definition for an augmentation element SHOULD begin with the standard opening phrase "Supplements..." or "Additional information about...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-33"><sch:title>Standard opening phrase for metadata element data definition</sch:title>
+ <sch:rule context="xs:element[ends-with(@name, 'Metadata')
+                               and not(xs:boolean(@abstract) eq true())]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '(metadata about|information that further qualifies)'))"
+     >The data definition for a metadata element SHOULD begin with the standard opening phrase "Metadata about..." or "Information that further qualifies...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-34"><sch:title>Standard opening phrase for association element data definition</sch:title>
+ <sch:rule context="xs:element[ends-with(@name, 'Association')
+                               and not(xs:boolean(@abstract) eq true())]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? (relationship|association)'))"
+     >The data definition for an association element that is not abstract SHOULD begin with the standard opening phrase "An (optional adjectives) (relationship|association)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-35"><sch:title>Standard opening phrase for abstract element data definition</sch:title>
+ <sch:rule context="xs:element[xs:boolean(@abstract) = true()
+                      and not(ends-with(@name, 'AugmentationPoint'))]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(starts-with(lower-case(normalize-space(.)), 'a data concept'))"
+     >The data definition for an abstract element SHOULD begin with the standard opening phrase "A data concept...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-36"><sch:title>Standard opening phrase for date element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Date') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? (date|month|year)'))"
+     >The data definition for an element or attribute with a date representation term SHOULD begin with the standard opening phrase "(A|An) (optional adjectives) (date|month|year)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-37"><sch:title>Standard opening phrase for quantity element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Quantity') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? (count|number)'))"
+     >The data definition for an element or attribute with a quantity representation term SHOULD begin with the standard opening phrase "An (optional adjectives) (count|number)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-38"><sch:title>Standard opening phrase for picture element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Picture') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? (image|picture|photograph)'))"
+     >The data definition for an element or attribute with a picture representation term SHOULD begin with the standard opening phrase "An (optional adjectives) (image|picture|photograph)".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-39"><sch:title>Standard opening phrase for indicator element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Indicator') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^true if .*; false (otherwise|if)'))"
+     >The data definition for an element or attribute with an indicator representation term SHOULD begin with the standard opening phrase "True if ...; false (otherwise|if)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-40"><sch:title>Standard opening phrase for identification element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Identification') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? identification'))"
+     >The data definition for an element or attribute with an identification representation term SHOULD begin with the standard opening phrase "(A|An) (optional adjectives) identification...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-41"><sch:title>Standard opening phrase for name element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Name') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^(a|an)( .*)? name'))"
+     >The data definition for an element or attribute with a name representation term SHOULD begin with the standard opening phrase "(A|An) (optional adjectives) name...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-42"><sch:title>Standard opening phrase for element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and @name
+                      and not(ends-with(@name, 'Indicator'))
+                      and not(ends-with(@name, 'Augmentation'))
+                      and not(ends-with(@name, 'Metadata'))
+                      and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an? '))"
+     >The data definition for an element or attribute declaration SHOULD begin with the standard opening phrase "(A|An)".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-43"><sch:title>Standard opening phrase for association type data definition</sch:title>
+ <sch:rule context="xs:complexType[ends-with(@name, 'AssociationType')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^a data type for (a relationship|an association)'))"
+     >The data definition for an association type SHOULD begin with the standard opening phrase "A data type for (a relationship|an association)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-44"><sch:title>Standard opening phrase for augmentation type data definition</sch:title>
+ <sch:rule context="xs:complexType[ends-with(@name, 'AugmentationType')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)),
+                         '^a data type (that supplements|for additional information about)'))"
+     >The data definition for an augmentation type SHOULD begin with the standard opening phrase "A data type (that supplements|for additional information about)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-45"><sch:title>Standard opening phrase for metadata type data definition</sch:title>
+ <sch:rule context="xs:complexType[ends-with(@name, 'MetadataType')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)),
+                         '^a data type for (metadata about|information that further qualifies)'))"
+     >The data definition for a metadata type SHOULD begin with the standard opening phrase "A data type for (metadata about|information that further qualifies)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-46"><sch:title>Standard opening phrase for complex type data definition</sch:title>
+ <sch:rule context="xs:complexType/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^a data type'))"
+     >The data definition for a complex type SHOULD begin with the standard opening phrase "A data type...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-47"><sch:title>Standard opening phrase for simple type data definition</sch:title>
+ <sch:rule context="xs:simpleType/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^a data type'))"
+     >The data definition for a simple type SHOULD begin with a standard opening phrase "A data type...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-52"><sch:title>Structures imported as conformant</sch:title>
+<sch:rule context="xs:import[exists(@namespace)
+                           and xs:anyURI(@namespace) = xs:anyURI(
+                   'https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/')]">
+<sch:assert test="empty(@appinfo:externalImportIndicator)"
+  >Rule 11-52: An import of the structures namespace MUST NOT be labeled as an external import.</sch:assert>
+</sch:rule>
+</sch:pattern><sch:pattern id="rule_11-53"><sch:title>XML namespace imported as conformant</sch:title>
+ <sch:rule context="xs:import[exists(@namespace)
+                              and xs:anyURI(@namespace) = xs:anyURI('http://www.w3.org/XML/1998/namespace')]">
+   <sch:assert test="empty(@appinfo:externalImportIndicator)"
+     >Rule 11-53: An import of the XML namespace MUST NOT be labeled as an external import.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-55"><sch:title>Consistently marked namespace imports</sch:title>
+ <sch:rule context="xs:import">
+   <sch:let name="namespace" value="@namespace"/>
+   <sch:let name="is-conformant" value="empty(@appinfo:externalImportIndicator)"/>
+   <sch:let name="first" value="exactly-one(parent::xs:schema/xs:import[@namespace = $namespace][1])"/>
+   <sch:assert test=". is $first
+                     or $is-conformant = empty($first/@appinfo:externalImportIndicator)"
+           >Rule 11-55: All xs:import elements that have the same namespace MUST have the same conformance marking via appinfo:externalImportIndicator.</sch:assert>
+ </sch:rule>
+</sch:pattern></sch:schema>

--- a/ndr-ct-msg.sch
+++ b/ndr-ct-msg.sch
@@ -1,0 +1,924 @@
+<?xml version="1.0" encoding="US-ASCII" standalone="yes"?>
+<sch:schema
+  xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform" queryBinding="xslt2">
+<sch:title>Rules for message XML Schema documents</sch:title>
+<xsl:include href="ndr-functions.xsl"/>
+<sch:ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
+<sch:ns prefix="xsl" uri="http://www.w3.org/1999/XSL/Transform"/>
+<sch:ns prefix="nf" uri="https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#NDRFunctions"/>
+<sch:ns prefix="ct" uri="https://docs.oasis-open.org/niemopen/ns/specification/conformanceTargets/3.0/"/>
+<sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+<sch:ns prefix="appinfo" uri="https://docs.oasis-open.org/niemopen/ns/model/appinfo/6.0/"/>
+<sch:ns prefix="structures" uri="https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/"/>
+<sch:pattern id="rule_4-6"><sch:title>Document element has attribute ct:conformanceTargets</sch:title>
+ <sch:rule context="*[. is nf:get-document-element(.)
+                      or exists(@ct:conformanceTargets)]">
+   <sch:assert test="(. is nf:get-document-element(.)) = exists(@ct:conformanceTargets)"
+     >Rule 4-6: The [document element] of the XML document, and only the [document element], MUST own an attribute {https://docs.oasis-open.org/niemopen/ns/specification/conformanceTargets/3.0/}conformanceTargets.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_4-10"><sch:title>Schema claims message conformance target</sch:title>
+ <sch:rule context="*[. is nf:get-document-element(.)]">
+   <sch:assert test="nf:has-effective-conformance-target-identifier(., xs:anyURI(https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#MessageSchemaDocument'))"
+     >Rule 4-10: The document MUST have an effective conformance target identifier of https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#MessageSchemaDocument.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-1"><sch:title>No base type in the XML namespace</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="namespace-uri-from-QName(resolve-QName(@base, .)) != xs:anyURI('http://www.w3.org/XML/1998/namespace')"
+     >Rule 9-1: A schema component must not have a base type definition with a {target namespace} that is the XML namespace.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-2"><sch:title>No base type of xs:ID</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:ID')"
+     >Rule 9-2: A schema component MUST NOT have an attribute {}base with a value of xs:ID.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-3"><sch:title>No base type of xs:IDREF</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:IDREF')"
+     >Rule 9-3: A schema component MUST NOT have an attribute {}base with a value of xs:IDREF.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-4"><sch:title>No base type of xs:IDREFS</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:IDREFS')"
+     >Rule 9-4: A schema component MUST NOT have an attribute {}base with a value of xs:IDREFS.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-5"><sch:title>No base type of xs:anyType</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:anyType')"
+     >Rule 9-5: A schema component MUST NOT have an attribute {}base with a value of xs:anyType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-6"><sch:title>No base type of xs:anySimpleType</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:anySimpleType')"
+     >Rule 9-6: A schema component MUST NOT have an attribute {}base with a value of xs:anySimpleType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-7"><sch:title>No base type of xs:NOTATION</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:NOTATION')"
+     >Rule 9-7: A schema component MUST NOT have an attribute {}base with a value of xs:NOTATION.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-8"><sch:title>No base type of xs:ENTITY</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:ENTITY')"
+     >Rule 9-8: A schema component MUST NOT have an attribute {}base with a value of xs:ENTITY.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-9"><sch:title>No base type of xs:ENTITIES</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:ENTITIES')"
+     >Rule 9-9: A schema component MUST NOT have an attribute {}base with a value of xs:ENTITIES.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-12"><sch:title>Simple type has data definition</sch:title>
+ <sch:rule context="xs:simpleType">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-12: A simple type MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-14"><sch:title>Enumeration has data definition</sch:title>
+ <sch:rule context="xs:enumeration">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-14: An enumeration facet MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-15"><sch:title>No list item type of xs:ID</sch:title>
+ <sch:rule context="xs:*[exists(@itemType)]">
+   <sch:assert test="resolve-QName(@itemType, .) != xs:QName('xs:ID')"
+     >Rule 9-15: A schema component MUST NOT have an attribute {}itemType with a value of xs:ID.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-16"><sch:title>No list item type of xs:IDREF</sch:title>
+ <sch:rule context="xs:*[exists(@itemType)]">
+   <sch:assert test="resolve-QName(@itemType, .) != xs:QName('xs:IDREF')"
+     >Rule 9-16: A schema component MUST NOT have an attribute {}itemType with a value of xs:IDREF.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-17"><sch:title>No list item type of xs:anySimpleType</sch:title>
+ <sch:rule context="xs:*[exists(@itemType)]">
+   <sch:assert test="resolve-QName(@itemType, .) != xs:QName('xs:anySimpleType')"
+     >Rule 9-17: A schema component MUST NOT have an attribute {}itemType with a value of xs:anySimpleType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-18"><sch:title>No list item type of xs:ENTITY</sch:title>
+ <sch:rule context="xs:*[exists(@itemType)]">
+   <sch:assert test="resolve-QName(@itemType, .) != xs:QName('xs:ENTITY')"
+     >Rule 9-18: A schema component MUST NOT have an attribute {}itemType with a value of xs:ENTITY.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-19"><sch:title>No union member types of xs:ID</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:ID')"
+     >Rule 9-19: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:ID.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-20"><sch:title>No union member types of xs:IDREF</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:IDREF')"
+     >Rule 9-20: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:IDREF.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-21"><sch:title>No union member types of xs:IDREFS</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:IDREFS')"
+     >Rule 9-21: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:IDREFS.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-22"><sch:title>No union member types of xs:anySimpleType</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:anySimpleType')"
+     >Rule 9-22: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:anySimpleType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-23"><sch:title>No union member types of xs:ENTITY</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:ENTITY')"
+     >Rule 9-23: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:ENTITY.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-24"><sch:title>No union member types of xs:ENTITIES</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:ENTITIES')"
+     >Rule 9-24: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:ENTITIES.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-26"><sch:title>Complex type has data definition</sch:title>
+ <sch:rule context="xs:complexType">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-26: A complex type MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-27"><sch:title>No mixed content on complex type</sch:title>
+ <sch:rule context="xs:complexType[exists(@mixed)]">
+   <sch:assert test="xs:boolean(@mixed) = false()"
+     >Rule 9-27: A complex type definition MUST NOT have mixed content.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-28"><sch:title>No mixed content on complex content</sch:title>
+ <sch:rule context="xs:complexContent[exists(@mixed)]">
+   <sch:assert test="xs:boolean(@mixed) = false()"
+     >Rule 9-28: A complex type definition with complex content MUST NOT have mixed content.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-29"><sch:title>Complex type content is explicitly simple or complex</sch:title>
+ <sch:rule context="xs:complexType">
+   <sch:assert test="exists(xs:simpleContent) or exists(xs:complexContent)"
+     >Rule 9-29: An element xs:complexType MUST have a child element xs:simpleContent or xs:complexContent.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-31"><sch:title>Base type of complex type with complex content must have complex content</sch:title>
+ <sch:rule context="xs:complexType/xs:complexContent/xs:*[
+                      (self::xs:extension or self::xs:restriction)
+                      and (some $base-qname in resolve-QName(@base, .) satisfies
+                             namespace-uri-from-QName($base-qname) = nf:get-target-namespace(.))]">
+   <sch:assert test="some $base-type in nf:resolve-type(., resolve-QName(@base, .)) satisfies
+                       empty($base-type/self::xs:complexType/xs:simpleContent)">Rule 9-31: 
+    The base type of complex type that has complex content MUST be a complex type with complex content.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-36"><sch:title>Element declaration is top-level</sch:title>
+ <sch:rule context="xs:element[exists(@name)]">
+   <sch:assert test="exists(parent::xs:schema)">Rule 9-36: 
+     An element declaration MUST be top-level.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-37"><sch:title>Element declaration has data definition</sch:title>
+ <sch:rule context="xs:element[exists(@name)]">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0">Rule 9-37: 
+     An element declaration MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-38"><sch:title>Untyped element is abstract</sch:title>
+ <sch:rule context="xs:schema/xs:element[empty(@type)]">
+   <sch:assert test="exists(@abstract)
+                     and xs:boolean(@abstract) = true()">Rule 9-38: 
+     A top-level element declaration that does not set the {type definition} property via the attribute "type" MUST have the {abstract} property with a value of "true".</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-39"><sch:title>Element of type xs:anySimpleType is abstract</sch:title>
+ <sch:rule context="xs:element[exists(@type)
+                               and resolve-QName(@type, .) = xs:QName('xs:anySimpleType')]">
+   <sch:assert test="exists(@abstract)
+                     and xs:boolean(@abstract) = true()">Rule 9-39: 
+               An element declaration that has a type xs:anySimpleType MUST have the {abstract} property with a value of "true".</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-41"><sch:title>Element type not in the XML namespace</sch:title>
+ <sch:rule context="xs:element[exists(@type)]">
+   <sch:assert test="namespace-uri-from-QName(resolve-QName(@type, .)) != 'http://www.w3.org/XML/1998/namespace'">Rule 9-41: 
+     An element type MUST NOT have a namespace name that is in the XML namespace.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-48"><sch:title>Attribute declaration is top-level</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:assert test="exists(parent::xs:schema)"
+     >Rule 9-48: An attribute declaration MUST be top-level.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-49"><sch:title>Attribute declaration has data definition</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-49: An attribute declaration MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-50"><sch:title>Attribute declaration has type</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:assert test="exists(@type)"
+     >Rule 9-50: A top-level attribute declaration MUST have a type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-51"><sch:title>No attribute type of xs:ID</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:ID')"
+     >Rule 9-51: A schema component MUST NOT have an attribute {}type with a value of xs:ID.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-52"><sch:title>No attribute type of xs:IDREF</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:IDREF')"
+     >Rule 9-52: A schema component MUST NOT have an attribute {}type with a value of xs:IDREF.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-53"><sch:title>No attribute type of xs:IDREFS</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:IDREFS')"
+     >Rule 9-53: A schema component MUST NOT have an attribute {}type with a value of xs:IDREFS.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-54"><sch:title>No attribute type of xs:ENTITY</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:ENTITY')"
+     >Rule 9-54: A schema component MUST NOT have an attribute {}type with a value of xs:ENTITY.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-55"><sch:title>No attribute type of xs:ENTITIES</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:ENTITIES')"
+     >Rule 9-55: A schema component MUST NOT have an attribute {}type with a value of xs:ENTITIES.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-56"><sch:title>No attribute type of xs:anySimpleType</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:anySimpleType')"
+     >Rule 9-56: A schema component MUST NOT have an attribute {}type with a value of xs:anySimpleType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-59"><sch:title>No use of element xs:notation</sch:title>
+ <sch:rule context="xs:notation">
+   <sch:assert test="false()"
+     >Rule 9-59: The schema MUST NOT contain the element xs:notation.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-61"><sch:title>No xs:all</sch:title>
+ <sch:rule context="xs:all">
+   <sch:assert test="false()"
+     >Rule 9-61: The schema MUST NOT contain the element xs:all</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-63"><sch:title>xs:sequence must be child of xs:extension or xs:restriction</sch:title>
+ <sch:rule context="xs:sequence">
+   <sch:assert test="exists(parent::xs:extension) or exists(parent::xs:restriction)"
+     >Rule 9-63: An element xs:sequence MUST be a child of element xs:extension or xs:restriction.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-65"><sch:title>xs:choice must be child of xs:sequence</sch:title>
+ <sch:rule context="xs:choice">
+   <sch:assert test="exists(parent::xs:sequence)"
+     >Rule 9-65: An element xs:choice MUST be a child of element xs:sequence.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-66"><sch:title>Sequence has minimum cardinality 1</sch:title>
+ <sch:rule context="xs:sequence">
+   <sch:assert test="empty(@minOccurs) or xs:integer(@minOccurs) = 1"
+     >Rule 9-66: An element xs:sequence MUST either not have the attribute {}minOccurs, or that attribute MUST have a value of 1.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-67"><sch:title>Sequence has maximum cardinality 1</sch:title>
+ <sch:rule context="xs:sequence">
+   <sch:assert test="empty(@maxOccurs) or (@maxOccurs instance of xs:integer
+                                           and 1 = xs:integer(@maxOccurs))"
+     >Rule 9-67: An element xs:sequence MUST either not have the attribute {}maxOccurs, or that attribute MUST have a value of 1.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-68"><sch:title>Choice has minimum cardinality 1</sch:title>
+ <sch:rule context="xs:choice">
+   <sch:assert test="empty(@minOccurs) or 1 = xs:integer(@minOccurs)"
+     >Rule 9-68: An element xs:choice MUST either not have the attribute {}minOccurs, or that attribute MUST have a value of 1.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-69"><sch:title>Choice has maximum cardinality 1</sch:title>
+ <sch:rule context="xs:choice">
+   <sch:assert test="empty(@maxOccurs) or (@maxOccurs instance of xs:integer
+                                           and 1 = xs:integer(@maxOccurs))"
+     >Rule 9-69: An element xs:choice MUST either not have the attribute {}maxOccurs, or that attribute MUST have a value of 1.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-72"><sch:title>No use of xs:unique</sch:title>
+ <sch:rule context="xs:unique">
+   <sch:assert test="false()"
+     >Rule 9-72: The schema MUST NOT contain the element xs:unique.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-73"><sch:title>No use of xs:key</sch:title>
+ <sch:rule context="xs:key">
+   <sch:assert test="false()"
+     >Rule 9-73: The schema MUST NOT contain the element xs:key.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-74"><sch:title>No use of xs:keyref</sch:title>
+ <sch:rule context="xs:keyref">
+   <sch:assert test="false()"
+     >Rule 9-74: The schema MUST NOT contain the element xs:keyref.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-75"><sch:title>No use of xs:group</sch:title>
+ <sch:rule context="xs:group">
+   <sch:assert test="false()"
+     >Rule 9-75: The schema MUST NOT contain the element xs:group.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-76"><sch:title>No definition of attribute groups</sch:title>
+ <sch:rule context="xs:attributeGroup[@name]">
+   <sch:assert test="false()"
+     >Rule 9-76: The schema MUST NOT contain an attribute group definition schema component.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-77"><sch:title>Comment is not recommended</sch:title>
+ <sch:rule context="node()[comment()]">
+   <sch:report test="true()" role="warning"
+     >An XML Comment is not an XML Schema annotation component; an XML comment SHOULD NOT appear in the schema.</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-78"><sch:title>Documentation element has no element children</sch:title>
+ <sch:rule context="xs:documentation/node()">
+   <sch:assert test="self::text() or self::comment()"
+     >Rule 9-78: A child of element xs:documentation MUST be text or an XML comment.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-79"><sch:title>xs:appinfo children are comments, elements, or whitespace</sch:title>
+ <sch:rule context="xs:appinfo/node()">
+   <sch:assert test="self::comment()
+                     or self::element()
+                     or self::text()[string-length(normalize-space(.)) = 0]"
+     >Rule 9-79: A child of element xs:appinfo MUST be an element, a comment, or whitespace text.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-80"><sch:title>Appinfo child elements have namespaces</sch:title>
+ <sch:rule context="xs:appinfo/*">
+   <sch:assert test="namespace-uri() != xs:anyURI('')"
+     >Rule 9-80: An element that is a child of xs:appinfo MUST have a namespace name.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-81"><sch:title>Appinfo descendants are not XML Schema elements</sch:title>
+ <sch:rule context="xs:appinfo//xs:*">
+   <sch:assert test="false()"
+     >Rule 9-81: An element with a namespace name of xs: MUST NOT have an ancestor element xs:appinfo.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-82"><sch:title>Schema has data definition</sch:title>
+ <sch:rule context="xs:schema">
+   <sch:assert test="some $definition in (xs:annotation/xs:documentation)[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-82: An element xs:schema MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-83"><sch:title>Schema document defines target namespace</sch:title>
+ <sch:rule context="xs:schema">
+   <sch:assert test="exists(@targetNamespace)"
+     >Rule 9-83: The schema MUST define a target namespace.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-85"><sch:title>Schema has version</sch:title>
+ <sch:rule context="xs:schema">
+   <sch:assert test="some $version in @version satisfies
+                     string-length(normalize-space(@version)) &gt; 0"
+       >Rule 9-85: An element xs:schema MUST have an attribute {}version that MUST NOT be empty.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-88"><sch:title>No use of xs:redefine</sch:title>
+ <sch:rule context="xs:redefine">
+   <sch:assert test="false()"
+     >Rule 9-88: The schema MUST NOT contain the element xs:redefine.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-89"><sch:title>No use of xs:include</sch:title>
+ <sch:rule context="xs:include">
+   <sch:assert test="false()"
+     >Rule 9-89: The schema MUST NOT contain the element xs:include.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-90"><sch:title>xs:import must have namespace</sch:title>
+ <sch:rule context="xs:import">
+   <sch:assert test="exists(@namespace)"
+     >Rule 9-90: An element xs:import MUST have an attribute {}namespace.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-92"><sch:title>Namespace referenced by attribute type is imported</sch:title>
+ <sch:rule context="xs:*[@type]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@type, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or $namespace = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace])"
+               >Rule 9-92: The namespace of a type referenced by @type MUST be the target namespace, the XML Schema namespace, or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-93"><sch:title>Namespace referenced by attribute base is imported</sch:title>
+ <sch:rule context="xs:*[@base]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@base, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or $namespace = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace])"
+               >Rule 9-93: The namespace of a type referenced by @base MUST be the target namespace, the XML Schema namespace, or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-94"><sch:title>Namespace referenced by attribute itemType is imported</sch:title>
+ <sch:rule context="xs:*[@itemType]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@itemType, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or $namespace = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace])"
+               >Rule 9-94: The namespace of a type referenced by @itemType MUST be the target namespace, the XML Schema namespace, or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-95"><sch:title>Namespaces referenced by attribute memberTypes is imported</sch:title>
+ <sch:rule context="xs:*[@memberTypes]">
+   <sch:assert test="every $type in tokenize(normalize-space(@memberTypes), ' '),
+                           $namespace in namespace-uri-from-QName(resolve-QName($type, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or $namespace = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace])"
+               >Rule 9-95: The namespace of a type referenced by @memberTypes MUST be the target namespace, the XML Schema namespace, or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-96"><sch:title>Namespace referenced by attribute ref is imported</sch:title>
+ <sch:rule context="xs:*[@ref]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies
+                       $namespace = nf:get-target-namespace(.)
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace]"
+               >Rule 9-96: The namespace of a component referenced by @ref MUST be the target namespace or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-97"><sch:title>Namespace referenced by attribute substitutionGroup is imported</sch:title>
+ <sch:rule context="xs:*[@substitutionGroup]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@substitutionGroup, .)) satisfies
+                       $namespace = nf:get-target-namespace(.)
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace]"
+               >Rule 9-97: The namespace of a component referenced by @substitutionGroup MUST be the target namespace or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-7"><sch:title>Import of external namespace has data definition</sch:title>
+ <sch:rule context="xs:import[@appinfo:externalImportIndicator]">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 10-7: An element xs:import that is annotated as importing an external schema document MUST be a documented component.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-9"><sch:title>Structure of external adapter type definition follows pattern</sch:title>
+ <sch:rule context="xs:complexType[@appinfo:externalAdapterTypeIndicator]">
+   <sch:assert test="xs:complexContent/xs:extension[
+                       resolve-QName(@base, .) = xs:QName('structures:ObjectType')
+                     ]/xs:sequence"
+     >Rule 10-9: An external adapter type definition MUST be a complex type definition with complex content that extends structures:ObjectType, and that uses xs:sequence as its top-level compositor.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-10"><sch:title>Element use from external adapter type defined by external schema documents</sch:title>
+ <sch:rule context="xs:element[@ref
+                               and exists(ancestor::xs:complexType[exists(@appinfo:externalAdapterTypeIndicator)])]">
+   <sch:assert test="some $ref-namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies
+                       nf:get-document-element(.)/xs:import[
+                         $ref-namespace = xs:anyURI(@namespace)
+                         and @appinfo:externalImportIndicator]"
+     >Rule 10-10: An element reference that appears within an external adapter type MUST have a target namespace that is imported as external.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-11"><sch:title>External adapter type not a base type</sch:title>
+ <sch:rule context="xs:*[(self::xs:extension or self::xs:restriction)
+                         and (some $base-qname in resolve-QName(@base, .),
+                                   $base-namespace in namespace-uri-from-QName($base-qname) satisfies
+                                nf:get-target-namespace(.) = $base-namespace)]">
+   <sch:assert test="nf:resolve-type(., resolve-QName(@base, .))[
+                       empty(@appinfo:externalAdapterTypeIndicator)]"
+      >Rule 10-11: An external adapter type definition MUST NOT be a base type definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-14"><sch:title>External attribute use has data definition</sch:title>
+ <sch:rule context="xs:attribute[some $ref-namespace in namespace-uri-from-QName(resolve-QName(@ref, .)),
+                                      $import in ancestor::xs:schema[1]/xs:import satisfies (
+                                   xs:anyURI($import/@namespace) = $ref-namespace
+                                   and exists(@appinfo:externalImportIndicator))]">
+   <sch:assert test="some $documentation in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($documentation))) &gt; 0"
+     >Rule 10-14: An external attribute use MUST be a documented component with a non-empty data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-16"><sch:title>External element use has data definition</sch:title>
+ <sch:rule context="xs:element[
+     some $ref-namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies
+       nf:get-document-element(.)/self::xs:schema//xs:import[
+         xs:anyURI(@namespace) = $ref-namespace
+         and @appinfo:externalImportIndicator]]">
+   <sch:assert test="some $documentation in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($documentation))) &gt; 0"
+     >Rule 10-16: An external attribute use MUST be a documented component with a non-empty data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-17"><sch:title>Name of code type ends in "CodeType"</sch:title>
+ <sch:rule context="xs:complexType[exists(xs:simpleContent[
+                      exists(xs:*[local-name() = ('extension', 'restriction')
+                                  and (ends-with(@base, 'CodeSimpleType')
+                                  or ends-with(@base, 'CodeType'))])])]">
+   <sch:report role="warning"
+       test="not(ends-with(@name, 'CodeType'))"
+     >A complex type definition with a {base type definition} of a code type or code simple type SHOULD have a {name} that ends in 'CodeType'.</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-19"><sch:title>Element of code type has code representation term</sch:title>
+ <sch:rule context="xs:element[exists(@name) and exists(@type) and ends-with(@type, 'CodeType')]">
+   <sch:report role="warning"
+       test="not(ends-with(@name, 'Code'))"
+     >An element with a type that is a code type SHOULD have a name with representation term "Code"</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-24"><sch:title>Augmentable type has at most one augmentation point element</sch:title>
+ <sch:rule context="xs:complexType[
+                      @name[not(ends-with(., 'MetadataType'))
+                            and not(ends-with(., 'AugmentationType'))]
+                      and empty(@appinfo:externalAdapterTypeIndicator)
+                      and xs:complexContent]">
+   <sch:let name="augmentation-point-qname"
+            value="QName(string(nf:get-target-namespace(.)),
+                         replace(./@name, 'Type$', 'AugmentationPoint'))"/>
+   <sch:assert test="count(xs:complexContent/xs:extension/xs:sequence/xs:element[
+                             @ref[resolve-QName(., ..) = $augmentation-point-qname]]) le 1"
+     >Rule 10-24: An augmentable type MUST contain no more than one element use of its corresponding augmentation point element.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-25"><sch:title>Augmentation point element corresponds to its base type</sch:title>
+ <sch:rule context="xs:element[exists(@name[
+                                matches(., 'AugmentationPoint$')])]">
+   <sch:let name="element-name" value="@name"/>
+   <sch:assert test="exists(
+                       parent::xs:schema/xs:complexType[
+                         @name = replace($element-name, 'AugmentationPoint$', 'Type')
+                         and exists(@name[
+                                 not(ends-with(., 'MetadataType'))
+                                 and not(ends-with(., 'AugmentationType'))])
+                               and empty(@appinfo:externalAdapterTypeIndicator)
+                               and exists(child::xs:complexContent)])"
+     >Rule 10-25: A schema document containing an element declaration for an augmentation point element MUST also contain a type definition for its base type, a corresponding augmentable type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-26"><sch:title>An augmentation point element has no type</sch:title>
+ <sch:rule context="xs:element[exists(@name[
+                                matches(., 'AugmentationPoint$')])]">
+   <sch:assert test="empty(@type)"
+       >Rule 10-26: An augmentation point element MUST have no type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-27"><sch:title>An augmentation point element has no substitution group</sch:title>
+ <sch:rule context="xs:element[exists(@name[
+                                matches(., 'AugmentationPoint$')])]">
+   <sch:assert test="empty(@substitutionGroup)"
+       >Rule 10-27: An augmentation point element MUST have no substitution group.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-28"><sch:title>Augmentation point element is only referenced by its base type</sch:title>
+ <sch:rule context="xs:complexType//xs:element[exists(@ref[
+                      matches(local-name-from-QName(resolve-QName(., ..)), 'AugmentationPoint$')]) ]">
+   <sch:assert test="QName(string(nf:get-target-namespace(ancestor::xs:complexType[1])), ancestor::xs:complexType[1]/@name)
+                     = QName(string(namespace-uri-from-QName(resolve-QName(@ref, .))),
+                         replace(local-name-from-QName(resolve-QName(@ref, .)), 'AugmentationPoint$', 'Type'))"
+     >Rule 10-28: An augmentation point element MUST only be referenced by its base type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-31"><sch:title>Augmentation point element use must be last element in its base type</sch:title>
+ <sch:rule context="xs:complexType//xs:element[exists(@ref[
+                          matches(local-name-from-QName(resolve-QName(., ..)), 'AugmentationPoint$')]) ]">
+   <sch:assert test="empty(following-sibling::*)"
+      >Rule 10-31: An augmentation point element particle MUST be the last element occurrence in its content model.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-34"><sch:title>Schema component with name ending in "AugmentationType" is an augmentation type</sch:title>
+ <sch:rule context="xs:*[ends-with(@name, 'AugmentationType')]">
+   <sch:assert test="self::xs:complexType/xs:complexContent/xs:*[
+                       (self::xs:extension or self::xs:restriction)
+                       and ends-with(@base, 'AugmentationType')]"
+      >Rule 10-34: An augmentation type definition schema component with {name} ending in 'AugmentationType' MUST be an augmentation type definition that is a complex type definition with complex content that extends or restricts an augmentation type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-35"><sch:title>Type derived from structures:AugmentationType is an augmentation type</sch:title>
+ <sch:rule context="xs:*[(self::xs:restriction or self::xs:extension)
+                         and ends-with(@base, 'AugmentationType')]">
+   <sch:assert test="ancestor::xs:complexType[ends-with(@name, 'AugmentationType')]"
+               >Rule 10-35: A type definition derived from an augmentation type MUST be an augmentation type definition</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-36"><sch:title>Augmentation element type is an augmentation type</sch:title>
+ <sch:rule context="xs:element[exists(@name)]">
+   <sch:assert test="exists(@type[ends-with(., 'AugmentationType')])
+                     = exists(@name[ends-with(., 'Augmentation')])"
+     >Rule 10-36: An element declaration MUST have a name that ends in "Augmentation" if and only if it has a type that is an augmentation type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-42"><sch:title>Name of element that ends in "Representation" is abstract</sch:title>
+ <sch:rule context="xs:element[@name[ends-with(., 'Representation')]]">
+   <sch:report role="warning"
+       test="empty(@abstract) or xs:boolean(@abstract) = false()"
+     >An element declaration with a name that ends in 'Representation' SHOULD have the {abstract} property with a value of "true".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-45"><sch:title>Schema component name has xml:lang</sch:title>
+ <sch:rule context="xs:*[exists(@name)]">
+   <sch:let name="xml-lang-attribute" value="ancestor-or-self::*[exists(@xml:lang)][1]/@xml:lang"/>
+   <sch:assert test="exists($xml-lang-attribute)
+                     and string-length(normalize-space($xml-lang-attribute)) gt 0"
+               >Rule 10-45: The name of an XML Schema component defined by the schema MUST be in the scope of an occurrence of attribute xml:lang that has a value that is not empty.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-46"><sch:title>Schema component names have only specific characters</sch:title>
+ <sch:rule context="xs:*[exists(@name)]">
+   <sch:assert test="matches(@name, '^[A-Za-z0-9\-_\.]*$')"
+     >Rule 10-46: The name of an XML Schema component defined by the schema must be composed of only the characters uppercase 'A' through 'Z', lowercase 'a' through 'z', numbers '0' through '9', underscore, hyphen, and period.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-49"><sch:title>Attribute name begins with lower case letter</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:assert test="matches(@name, '^[a-z]')"
+     >Rule 10-49: Within the schema, any attribute declaration MUST have a name that begins with a lowercase letter
+     ('a'-'z').</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-50"><sch:title>Name of schema component other than attribute and proxy type begins with upper case letter</sch:title>
+ <sch:rule context="xs:attribute">
+   <sch:report test="false()" role="warning">This rule does not apply to an attribute.</sch:report>
+ </sch:rule>
+ <sch:rule context="xs:complexType[some $name in @name,
+                                   $extension in xs:simpleContent/xs:extension,
+                                   $base-qname in resolve-QName($extension/@base, $extension) satisfies
+                                   $base-qname = QName('http://www.w3.org/2001/XMLSchema', $name)]">
+   <sch:report test="false()" role="warning">This rule does not apply to a proxy types.</sch:report>
+ </sch:rule>
+ <sch:rule context="xs:*[exists(@name)]">
+   <sch:assert test="matches(@name, '^[A-Z]')"
+     >Rule 10-50: Within the schema, an XML Schema component that is not an attribute declaration or proxy type MUST have a name that begins with an upper-case letter ('A'-'Z').</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-69"><sch:title>Deprecated annotates schema component</sch:title>
+ <sch:rule context="*[exists(@appinfo:deprecated)]">
+   <sch:assert test="namespace-uri-from-QName(node-name(.)) = xs:anyURI('http://www.w3.org/2001/XMLSchema')"
+           >Rule 10-69: The attribute appinfo:deprecated MUST be owned by an element with a namespace name http://www.w3.org/2001/XMLSchema.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-70"><sch:title>External import indicator annotates import</sch:title>
+ <sch:rule context="*[exists(@appinfo:externalImportIndicator)]">
+   <sch:assert test="exists(self::xs:import)"
+       >Rule 10-70: The attribute {https://docs.oasis-open.org/niemopen/ns/model/appinfo/6.0/}externalImportIndicator MUST be owned by an element xs:import.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-71"><sch:title>External adapter type indicator annotates complex type</sch:title>
+ <sch:rule context="*[exists(@appinfo:externalAdapterTypeIndicator)]">
+   <sch:assert test="exists(self::xs:complexType)"
+           >Rule 10-71: The attribute appinfo:externalAdapterTypeIndicator MUST be owned by an element xs:complexType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-76"><sch:title>appinfo:LocalTerm annotates schema</sch:title>
+ <sch:rule context="appinfo:LocalTerm">
+   <sch:assert test="parent::xs:appinfo[parent::xs:annotation[parent::xs:schema]]"
+     >Rule 10-76: The element appinfo:LocalTerm MUST be application information on an element xs:schema.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-77"><sch:title>appinfo:LocalTerm has literal or definition</sch:title>
+ <sch:rule context="appinfo:LocalTerm">
+   <sch:assert test="exists(@literal) or exists(@definition)"
+           >Rule 10-77: The element {https://docs.oasis-open.org/niemopen/ns/model/appinfo/6.0/}LocalTerm MUST have a literal or definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-1"><sch:title>Name of type ends in "Type"</sch:title>
+ <sch:rule context="xs:complexType[some $name in @name,
+                                   $extension in xs:simpleContent/xs:extension,
+                                   $base-qname in resolve-QName($extension/@base, $extension) satisfies
+                                   $base-qname = QName('http://www.w3.org/2001/XMLSchema', $name)]">
+   <sch:report test="false()" role="warning">The name of a proxy type does not end in "Type".</sch:report>
+ </sch:rule>
+ <sch:rule context="xs:*[(self::xs:simpleType or self::xs:complexType) and exists(@name)]">
+   <sch:assert test="ends-with(@name, 'Type')"
+     >Rule 11-1: A type definition schema component that does not define a proxy type MUST have a name that ends in "Type".</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-2"><sch:title>Only types have name ending in "Type" or "SimpleType"</sch:title>
+ <sch:rule context="xs:*[exists(@name) and ends-with(@name, 'SimpleType')]">
+   <sch:assert test="local-name() = 'simpleType'"
+               >Rule 11-2: A schema component with a name that ends in 'SimpleType' MUST be a simple type definition.</sch:assert>
+ </sch:rule>
+ <sch:rule context="xs:*[exists(@name) and ends-with(@name, 'Type')]">
+   <sch:assert test="local-name() = 'complexType'"
+               >A schema component with a name that ends in 'Type' and does not end in 'SimpleType' MUST be a complex type definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-3"><sch:title>Base type definition defined by conformant schema</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="some $base-namespace in namespace-uri-from-QName(resolve-QName(@base, .)) satisfies (
+                       $base-namespace = (nf:get-target-namespace(.), xs:anyURI('http://www.w3.org/2001/XMLSchema'))
+                       or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                                                  and $base-namespace = xs:anyURI(@namespace)
+                                                                  and empty(@appinfo:externalImportIndicator)]))"
+     >Rule 11-3: The {base type definition} of a type definition MUST have the target namespace or the XML Schema namespace or a namespace that is imported as conformant.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-4"><sch:title>Name of simple type ends in "SimpleType"</sch:title>
+ <sch:rule context="xs:simpleType[@name]">
+   <sch:assert test="ends-with(@name, 'SimpleType')"
+     >Rule 11-4: A simple type definition schema component MUST have a name that ends in "SimpleType".</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-6"><sch:title>List item type defined by conformant schemas</sch:title>
+ <sch:rule context="xs:list[exists(@itemType)]">
+   <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@itemType, .))"/>
+   <sch:assert test="$namespace = (nf:get-target-namespace(.), xs:anyURI('http://www.w3.org/2001/XMLSchema'))
+                     or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                   and $namespace = xs:anyURI(@namespace)
+                                   and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-6: The item type of a list simple type definition MUST have a target namespace equal to the target namespace of the XML Schema document within which it is defined, or a namespace that is imported as conformant by the schema document within which it is defined.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-7"><sch:title>Union member types defined by conformant schemas</sch:title>
+ <sch:rule context="xs:union[exists(@memberTypes)]">
+   <sch:assert test="every $qname in tokenize(normalize-space(@memberTypes), ' '),
+                           $namespace in namespace-uri-from-QName(resolve-QName($qname, .))
+                     satisfies ($namespace = nf:get-target-namespace(.)
+                                or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                          and $namespace = xs:anyURI(@namespace)
+                                          and empty(@appinfo:externalImportIndicator)]))"
+               >Rule 11-7: Every member type of a union simple type definition MUST have a target namespace that is equal to either the target namespace of the XML Schema document within which it is defined or a namespace that is imported as conformant by the schema document within which it is defined.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-10"><sch:title>Attribute of code simple type has code representation term</sch:title>
+ <sch:rule context="xs:attribute[exists(@name) and exists(@type) and ends-with(@type, 'CodeSimpleType')]">
+   <sch:report test="not(ends-with(@name, 'Code'))" role="warning"
+     >An attribute with a type that is a code simple type SHOULD have a name with representation term "Code"</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-12"><sch:title>Element type does not have a simple type name</sch:title>
+ <sch:rule context="xs:element[exists(@type)]">
+   <sch:assert test="not(ends-with(@type, 'SimpleType'))"
+               >Rule 11-12: The {type definition} of an element declaration MUST NOT have a {name} that ends in 'SimpleType'.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-13"><sch:title>Element type is from conformant namespace</sch:title>
+ <sch:rule context="xs:element[exists(@type)]">
+   <sch:assert test="for $type-qname in resolve-QName(@type, .),
+                         $type-namespace in namespace-uri-from-QName($type-qname) return
+                       $type-namespace = nf:get-target-namespace(.)
+                       or exists(nf:get-document-element(.)/xs:import[
+                                   xs:anyURI(@namespace) = $type-namespace
+                                   and empty(@appinfo:externalImportIndicator)])"
+               >Rule 11-13: The {type definition} of an element declaration MUST have a {target namespace} that is the target namespace, or one that is imported as conformant.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-14"><sch:title>Name of element that ends in "Abstract" is abstract</sch:title>
+ <sch:rule context="xs:element[@name]">
+   <sch:report role="warning"
+       test="not(exists(@abstract[xs:boolean(.) = true()])
+                 eq (ends-with(@name, 'Abstract')
+                     or ends-with(@name, 'AugmentationPoint')
+                     or ends-with(@name, 'Representation')))"
+     >An element declaration SHOULD have a name that ends in 'Abstract', 'AugmentationPoint', or 'Representation' if and only if it has the {abstract} property with a value of "true".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-15"><sch:title>Name of element declaration with simple content has representation term</sch:title>
+ <sch:rule context="xs:element[@name and @type
+                               and (some $type-qname in resolve-QName(@type, .) satisfies (
+                                      nf:get-target-namespace(.) = namespace-uri-from-QName($type-qname)
+                                      and nf:resolve-type(., $type-qname)/xs:simpleContent))]">
+   <sch:report role="warning"
+       test="every $representation-term
+             in ('Amount', 'BinaryObject', 'Graphic', 'Picture', 'Sound', 'Video', 'Code', 'DateTime', 'Date', 'Time', 'Duration', 'ID', 'URI', 'Indicator', 'Measure', 'Numeric', 'Value', 'Rate', 'Percent', 'Quantity', 'Text', 'Name', 'List')
+             satisfies not(ends-with(@name, $representation-term))"
+     >The name of an element declaration that is of simple content SHOULD use a representation term.</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-17"><sch:title>Element substitution group defined by conformant schema</sch:title>
+ <sch:rule context="xs:element[exists(@substitutionGroup)]">
+   <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@substitutionGroup, .))"/>
+   <sch:assert test="$namespace = nf:get-target-namespace(.)
+                     or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                   and $namespace = xs:anyURI(@namespace)
+                                   and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-17: An element substitution group MUST have either the target namespace or a namespace that is imported as conformant.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-18"><sch:title>Attribute type defined by conformant schema</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@type, .))"/>
+   <sch:assert test="$namespace = (nf:get-target-namespace(.), xs:anyURI('http://www.w3.org/2001/XMLSchema'))
+                     or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                   and $namespace = xs:anyURI(@namespace)
+                                   and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-18: The type of an attribute declaration MUST have the target namespace or the XML Schema namespace or a namespace that is imported as conformant.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-19"><sch:title>Attribute name uses representation term</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:report role="warning"
+       test="every $representation-term
+             in ('Amount', 'BinaryObject', 'Graphic', 'Picture', 'Sound', 'Video', 'Code', 'DateTime', 'Date', 'Time', 'Duration', 'ID', 'URI', 'Indicator', 'Measure', 'Numeric', 'Value', 'Rate', 'Percent', 'Quantity', 'Text', 'Name', 'List')
+             satisfies not(ends-with(@name, $representation-term))"
+     >An attribute name SHOULD end with a representation term.</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-21"><sch:title>Element reference defined by conformant schema</sch:title>
+ <sch:rule context="xs:element[exists(ancestor::xs:complexType[empty(@appinfo:externalAdapterTypeIndicator)]) and @ref]">
+   <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@ref, .))"/>
+   <sch:assert test="$namespace = nf:get-target-namespace(.)
+                     or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                   and $namespace = xs:anyURI(@namespace)
+                                   and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-21: An element reference MUST be to a component that has a namespace that is either the target namespace of the schema document in which it appears, or which is imported as conformant by that schema document.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-22"><sch:title>Referenced attribute defined by conformant schemas</sch:title>
+  <sch:rule context="xs:attribute[@ref]">
+     <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@ref, .))"/>
+     <sch:assert test="some $namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or ancestor::xs:schema[1]/xs:import[
+                            @namespace
+                            and $namespace = xs:anyURI(@namespace)
+                            and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-22: An attribute {}ref MUST have the target namespace or a namespace that is imported as conformant.     </sch:assert>
+  </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-23"><sch:title>Schema uses only known attribute groups</sch:title>
+  <sch:rule context="xs:attributeGroup[@ref]">
+    <sch:assert test="some $ref in resolve-QName(@ref, .) satisfies (
+                        $ref = xs:QName('structures:SimpleObjectAttributeGroup'))"
+      >Rule 11-23: An attribute group reference MUST be structures:SimpleObjectAttributeGroup</sch:assert>
+  </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-30"><sch:title>xs:documentation has xml:lang</sch:title>
+ <sch:rule context="xs:documentation">
+   <sch:let name="xml-lang-attribute" value="ancestor-or-self::*[exists(@xml:lang)][1]/@xml:lang"/>
+   <sch:assert test="exists($xml-lang-attribute)
+                     and string-length(normalize-space($xml-lang-attribute)) gt 0"
+               >Rule 11-30: An occurrence of xs:documentation within the schema MUST be in the scope of an occurrence of attribute xml:lang that has a value that is not empty.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-31"><sch:title>Standard opening phrase for augmentation point element data definition</sch:title>
+ <sch:rule context="xs:element[ends-with(@name, 'AugmentationPoint')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(starts-with(lower-case(normalize-space(.)), 'an augmentation point '))"
+     >The data definition for an augmentation point element SHOULD begin with standard opening phrase "An augmentation point...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-32"><sch:title>Standard opening phrase for augmentation element data definition</sch:title>
+ <sch:rule context="xs:element[ends-with(@name, 'Augmentation')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="every $phrase
+             in ('supplements ', 'additional information about ')
+             satisfies not(starts-with(lower-case(normalize-space(.)), $phrase))"
+     >The data definition for an augmentation element SHOULD begin with the standard opening phrase "Supplements..." or "Additional information about...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-33"><sch:title>Standard opening phrase for metadata element data definition</sch:title>
+ <sch:rule context="xs:element[ends-with(@name, 'Metadata')
+                               and not(xs:boolean(@abstract) eq true())]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '(metadata about|information that further qualifies)'))"
+     >The data definition for a metadata element SHOULD begin with the standard opening phrase "Metadata about..." or "Information that further qualifies...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-34"><sch:title>Standard opening phrase for association element data definition</sch:title>
+ <sch:rule context="xs:element[ends-with(@name, 'Association')
+                               and not(xs:boolean(@abstract) eq true())]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? (relationship|association)'))"
+     >The data definition for an association element that is not abstract SHOULD begin with the standard opening phrase "An (optional adjectives) (relationship|association)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-35"><sch:title>Standard opening phrase for abstract element data definition</sch:title>
+ <sch:rule context="xs:element[xs:boolean(@abstract) = true()
+                      and not(ends-with(@name, 'AugmentationPoint'))]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(starts-with(lower-case(normalize-space(.)), 'a data concept'))"
+     >The data definition for an abstract element SHOULD begin with the standard opening phrase "A data concept...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-36"><sch:title>Standard opening phrase for date element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Date') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? (date|month|year)'))"
+     >The data definition for an element or attribute with a date representation term SHOULD begin with the standard opening phrase "(A|An) (optional adjectives) (date|month|year)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-37"><sch:title>Standard opening phrase for quantity element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Quantity') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? (count|number)'))"
+     >The data definition for an element or attribute with a quantity representation term SHOULD begin with the standard opening phrase "An (optional adjectives) (count|number)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-38"><sch:title>Standard opening phrase for picture element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Picture') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? (image|picture|photograph)'))"
+     >The data definition for an element or attribute with a picture representation term SHOULD begin with the standard opening phrase "An (optional adjectives) (image|picture|photograph)".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-39"><sch:title>Standard opening phrase for indicator element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Indicator') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^true if .*; false (otherwise|if)'))"
+     >The data definition for an element or attribute with an indicator representation term SHOULD begin with the standard opening phrase "True if ...; false (otherwise|if)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-40"><sch:title>Standard opening phrase for identification element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Identification') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? identification'))"
+     >The data definition for an element or attribute with an identification representation term SHOULD begin with the standard opening phrase "(A|An) (optional adjectives) identification...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-41"><sch:title>Standard opening phrase for name element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Name') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^(a|an)( .*)? name'))"
+     >The data definition for an element or attribute with a name representation term SHOULD begin with the standard opening phrase "(A|An) (optional adjectives) name...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-42"><sch:title>Standard opening phrase for element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and @name
+                      and not(ends-with(@name, 'Indicator'))
+                      and not(ends-with(@name, 'Augmentation'))
+                      and not(ends-with(@name, 'Metadata'))
+                      and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an? '))"
+     >The data definition for an element or attribute declaration SHOULD begin with the standard opening phrase "(A|An)".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-43"><sch:title>Standard opening phrase for association type data definition</sch:title>
+ <sch:rule context="xs:complexType[ends-with(@name, 'AssociationType')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^a data type for (a relationship|an association)'))"
+     >The data definition for an association type SHOULD begin with the standard opening phrase "A data type for (a relationship|an association)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-44"><sch:title>Standard opening phrase for augmentation type data definition</sch:title>
+ <sch:rule context="xs:complexType[ends-with(@name, 'AugmentationType')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)),
+                         '^a data type (that supplements|for additional information about)'))"
+     >The data definition for an augmentation type SHOULD begin with the standard opening phrase "A data type (that supplements|for additional information about)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-45"><sch:title>Standard opening phrase for metadata type data definition</sch:title>
+ <sch:rule context="xs:complexType[ends-with(@name, 'MetadataType')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)),
+                         '^a data type for (metadata about|information that further qualifies)'))"
+     >The data definition for a metadata type SHOULD begin with the standard opening phrase "A data type for (metadata about|information that further qualifies)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-46"><sch:title>Standard opening phrase for complex type data definition</sch:title>
+ <sch:rule context="xs:complexType/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^a data type'))"
+     >The data definition for a complex type SHOULD begin with the standard opening phrase "A data type...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-47"><sch:title>Standard opening phrase for simple type data definition</sch:title>
+ <sch:rule context="xs:simpleType/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^a data type'))"
+     >The data definition for a simple type SHOULD begin with a standard opening phrase "A data type...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-52"><sch:title>Structures imported as conformant</sch:title>
+<sch:rule context="xs:import[exists(@namespace)
+                           and xs:anyURI(@namespace) = xs:anyURI(
+                   'https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/')]">
+<sch:assert test="empty(@appinfo:externalImportIndicator)"
+  >Rule 11-52: An import of the structures namespace MUST NOT be labeled as an external import.</sch:assert>
+</sch:rule>
+</sch:pattern><sch:pattern id="rule_11-53"><sch:title>XML namespace imported as conformant</sch:title>
+ <sch:rule context="xs:import[exists(@namespace)
+                              and xs:anyURI(@namespace) = xs:anyURI('http://www.w3.org/XML/1998/namespace')]">
+   <sch:assert test="empty(@appinfo:externalImportIndicator)"
+     >Rule 11-53: An import of the XML namespace MUST NOT be labeled as an external import.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-55"><sch:title>Consistently marked namespace imports</sch:title>
+ <sch:rule context="xs:import">
+   <sch:let name="namespace" value="@namespace"/>
+   <sch:let name="is-conformant" value="empty(@appinfo:externalImportIndicator)"/>
+   <sch:let name="first" value="exactly-one(parent::xs:schema/xs:import[@namespace = $namespace][1])"/>
+   <sch:assert test=". is $first
+                     or $is-conformant = empty($first/@appinfo:externalImportIndicator)"
+           >Rule 11-55: All xs:import elements that have the same namespace MUST have the same conformance marking via appinfo:externalImportIndicator.</sch:assert>
+ </sch:rule>
+</sch:pattern></sch:schema>

--- a/ndr-ct-ref.sch
+++ b/ndr-ct-ref.sch
@@ -1,0 +1,1116 @@
+<?xml version="1.0" encoding="US-ASCII" standalone="yes"?>
+<sch:schema
+  xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform" queryBinding="xslt2">
+<sch:title>Rules for reference XML Schema documents</sch:title>
+<xsl:include href="ndr-functions.xsl"/>
+<sch:ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
+<sch:ns prefix="xsl" uri="http://www.w3.org/1999/XSL/Transform"/>
+<sch:ns prefix="nf" uri="https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#NDRFunctions"/>
+<sch:ns prefix="ct" uri="https://docs.oasis-open.org/niemopen/ns/specification/conformanceTargets/3.0/"/>
+<sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+<sch:ns prefix="appinfo" uri="https://docs.oasis-open.org/niemopen/ns/model/appinfo/6.0/"/>
+<sch:ns prefix="structures" uri="https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/"/>
+<sch:pattern id="rule_4-6"><sch:title>Document element has attribute ct:conformanceTargets</sch:title>
+ <sch:rule context="*[. is nf:get-document-element(.)
+                      or exists(@ct:conformanceTargets)]">
+   <sch:assert test="(. is nf:get-document-element(.)) = exists(@ct:conformanceTargets)"
+     >Rule 4-6: The [document element] of the XML document, and only the [document element], MUST own an attribute {https://docs.oasis-open.org/niemopen/ns/specification/conformanceTargets/3.0/}conformanceTargets.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-1"><sch:title>No base type in the XML namespace</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="namespace-uri-from-QName(resolve-QName(@base, .)) != xs:anyURI('http://www.w3.org/XML/1998/namespace')"
+     >Rule 9-1: A schema component must not have a base type definition with a {target namespace} that is the XML namespace.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-2"><sch:title>No base type of xs:ID</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:ID')"
+     >Rule 9-2: A schema component MUST NOT have an attribute {}base with a value of xs:ID.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-3"><sch:title>No base type of xs:IDREF</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:IDREF')"
+     >Rule 9-3: A schema component MUST NOT have an attribute {}base with a value of xs:IDREF.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-4"><sch:title>No base type of xs:IDREFS</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:IDREFS')"
+     >Rule 9-4: A schema component MUST NOT have an attribute {}base with a value of xs:IDREFS.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-5"><sch:title>No base type of xs:anyType</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:anyType')"
+     >Rule 9-5: A schema component MUST NOT have an attribute {}base with a value of xs:anyType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-6"><sch:title>No base type of xs:anySimpleType</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:anySimpleType')"
+     >Rule 9-6: A schema component MUST NOT have an attribute {}base with a value of xs:anySimpleType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-7"><sch:title>No base type of xs:NOTATION</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:NOTATION')"
+     >Rule 9-7: A schema component MUST NOT have an attribute {}base with a value of xs:NOTATION.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-8"><sch:title>No base type of xs:ENTITY</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:ENTITY')"
+     >Rule 9-8: A schema component MUST NOT have an attribute {}base with a value of xs:ENTITY.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-9"><sch:title>No base type of xs:ENTITIES</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:ENTITIES')"
+     >Rule 9-9: A schema component MUST NOT have an attribute {}base with a value of xs:ENTITIES.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-10"><sch:title>Simple type definition is top-level</sch:title>
+ <sch:rule context="xs:simpleType">
+   <sch:assert test="exists(parent::xs:schema)"
+     >Rule 9-10: A simple type definition MUST be top-level.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-11"><sch:title>No simple type disallowed derivation</sch:title>
+ <sch:rule context="xs:simpleType">
+   <sch:assert test="empty(@final)"
+     >Rule 9-11: An element xs:simpleType MUST NOT have an attribute {}final.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-12"><sch:title>Simple type has data definition</sch:title>
+ <sch:rule context="xs:simpleType">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-12: A simple type MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-13"><sch:title>No use of "fixed" on simple type facets</sch:title>
+ <sch:rule context="xs:*[self::xs:length or self::xs:minLength or self::xs:maxLength or self::xs:whiteSpace
+     or self::xs:maxInclusive or self::xs:maxExclusive or self::xs:minExclusive or self::xs:minInclusive
+     or self::xs:totalDigits or self::xs:fractionDigits]">
+   <sch:assert test="empty(@fixed)"
+     >Rule 9-13: A simple type constraining facet MUST NOT have an attribute {}fixed.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-14"><sch:title>Enumeration has data definition</sch:title>
+ <sch:rule context="xs:enumeration">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-14: An enumeration facet MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-15"><sch:title>No list item type of xs:ID</sch:title>
+ <sch:rule context="xs:*[exists(@itemType)]">
+   <sch:assert test="resolve-QName(@itemType, .) != xs:QName('xs:ID')"
+     >Rule 9-15: A schema component MUST NOT have an attribute {}itemType with a value of xs:ID.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-16"><sch:title>No list item type of xs:IDREF</sch:title>
+ <sch:rule context="xs:*[exists(@itemType)]">
+   <sch:assert test="resolve-QName(@itemType, .) != xs:QName('xs:IDREF')"
+     >Rule 9-16: A schema component MUST NOT have an attribute {}itemType with a value of xs:IDREF.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-17"><sch:title>No list item type of xs:anySimpleType</sch:title>
+ <sch:rule context="xs:*[exists(@itemType)]">
+   <sch:assert test="resolve-QName(@itemType, .) != xs:QName('xs:anySimpleType')"
+     >Rule 9-17: A schema component MUST NOT have an attribute {}itemType with a value of xs:anySimpleType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-18"><sch:title>No list item type of xs:ENTITY</sch:title>
+ <sch:rule context="xs:*[exists(@itemType)]">
+   <sch:assert test="resolve-QName(@itemType, .) != xs:QName('xs:ENTITY')"
+     >Rule 9-18: A schema component MUST NOT have an attribute {}itemType with a value of xs:ENTITY.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-19"><sch:title>No union member types of xs:ID</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:ID')"
+     >Rule 9-19: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:ID.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-20"><sch:title>No union member types of xs:IDREF</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:IDREF')"
+     >Rule 9-20: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:IDREF.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-21"><sch:title>No union member types of xs:IDREFS</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:IDREFS')"
+     >Rule 9-21: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:IDREFS.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-22"><sch:title>No union member types of xs:anySimpleType</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:anySimpleType')"
+     >Rule 9-22: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:anySimpleType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-23"><sch:title>No union member types of xs:ENTITY</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:ENTITY')"
+     >Rule 9-23: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:ENTITY.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-24"><sch:title>No union member types of xs:ENTITIES</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:ENTITIES')"
+     >Rule 9-24: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:ENTITIES.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-25"><sch:title>Complex type definition is top-level</sch:title>
+ <sch:rule context="xs:complexType">
+   <sch:assert test="exists(parent::xs:schema)"
+     >Rule 9-25: A complex type definition MUST be top-level.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-26"><sch:title>Complex type has data definition</sch:title>
+ <sch:rule context="xs:complexType">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-26: A complex type MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-27"><sch:title>No mixed content on complex type</sch:title>
+ <sch:rule context="xs:complexType[exists(@mixed)]">
+   <sch:assert test="xs:boolean(@mixed) = false()"
+     >Rule 9-27: A complex type definition MUST NOT have mixed content.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-28"><sch:title>No mixed content on complex content</sch:title>
+ <sch:rule context="xs:complexContent[exists(@mixed)]">
+   <sch:assert test="xs:boolean(@mixed) = false()"
+     >Rule 9-28: A complex type definition with complex content MUST NOT have mixed content.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-29"><sch:title>Complex type content is explicitly simple or complex</sch:title>
+ <sch:rule context="xs:complexType">
+   <sch:assert test="exists(xs:simpleContent) or exists(xs:complexContent)"
+     >Rule 9-29: An element xs:complexType MUST have a child element xs:simpleContent or xs:complexContent.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-30"><sch:title>Complex content uses extension</sch:title>
+ <sch:rule context="xs:complexContent">
+   <sch:assert test="exists(xs:extension)"
+     >Rule 9-30: An element xs:complexContent MUST have a child xs:extension.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-31"><sch:title>Base type of complex type with complex content must have complex content</sch:title>
+ <sch:rule context="xs:complexType/xs:complexContent/xs:*[
+                      (self::xs:extension or self::xs:restriction)
+                      and (some $base-qname in resolve-QName(@base, .) satisfies
+                             namespace-uri-from-QName($base-qname) = nf:get-target-namespace(.))]">
+   <sch:assert test="some $base-type in nf:resolve-type(., resolve-QName(@base, .)) satisfies
+                       empty($base-type/self::xs:complexType/xs:simpleContent)">Rule 9-31: 
+    The base type of complex type that has complex content MUST be a complex type with complex content.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-33"><sch:title>Simple content uses extension</sch:title>
+ <sch:rule context="xs:simpleContent">
+   <sch:assert test="exists(xs:extension)">Rule 9-33: 
+     A complex type definition with simple content schema component MUST have a derivation method of extension.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-34"><sch:title>No complex type disallowed substitutions</sch:title>
+ <sch:rule context="xs:complexType">
+   <sch:assert test="empty(@block)">Rule 9-34: 
+     An element xs:complexType MUST NOT have an attribute {}block.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-35"><sch:title>No complex type disallowed derivation</sch:title>
+ <sch:rule context="xs:complexType">
+   <sch:assert test="empty(@final)">Rule 9-35: 
+     An element xs:complexType MUST NOT have an attribute {}final.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-36"><sch:title>Element declaration is top-level</sch:title>
+ <sch:rule context="xs:element[exists(@name)]">
+   <sch:assert test="exists(parent::xs:schema)">Rule 9-36: 
+     An element declaration MUST be top-level.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-37"><sch:title>Element declaration has data definition</sch:title>
+ <sch:rule context="xs:element[exists(@name)]">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0">Rule 9-37: 
+     An element declaration MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-38"><sch:title>Untyped element is abstract</sch:title>
+ <sch:rule context="xs:schema/xs:element[empty(@type)]">
+   <sch:assert test="exists(@abstract)
+                     and xs:boolean(@abstract) = true()">Rule 9-38: 
+     A top-level element declaration that does not set the {type definition} property via the attribute "type" MUST have the {abstract} property with a value of "true".</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-39"><sch:title>Element of type xs:anySimpleType is abstract</sch:title>
+ <sch:rule context="xs:element[exists(@type)
+                               and resolve-QName(@type, .) = xs:QName('xs:anySimpleType')]">
+   <sch:assert test="exists(@abstract)
+                     and xs:boolean(@abstract) = true()">Rule 9-39: 
+               An element declaration that has a type xs:anySimpleType MUST have the {abstract} property with a value of "true".</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-41"><sch:title>Element type not in the XML namespace</sch:title>
+ <sch:rule context="xs:element[exists(@type)]">
+   <sch:assert test="namespace-uri-from-QName(resolve-QName(@type, .)) != 'http://www.w3.org/XML/1998/namespace'">Rule 9-41: 
+     An element type MUST NOT have a namespace name that is in the XML namespace.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-42"><sch:title>Element type is not simple type</sch:title>
+ <sch:rule context="xs:element[@type]">
+   <sch:assert test="every $type-qname in resolve-QName(@type, .),
+                           $type-ns in namespace-uri-from-QName($type-qname),
+                           $type-local-name in local-name-from-QName($type-qname) satisfies (
+                       $type-qname = xs:QName('xs:anySimpleType')
+                       or (($type-ns = nf:get-target-namespace(.)
+                            or exists(nf:get-document-element(.)/xs:import[
+                                        xs:anyURI(@namespace) = $type-ns
+                                        and empty(@appinfo:externalImportIndicator)]))
+                           and not(ends-with($type-local-name, 'SimpleType'))))">Rule 9-42: 
+     An element type that is not xs:anySimpleType MUST NOT be a simple type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-43"><sch:title>No element disallowed substitutions</sch:title>
+ <sch:rule context="xs:element">
+   <sch:assert test="empty(@block)">Rule 9-43: 
+     An element xs:element MUST NOT have an attribute {}block.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-44"><sch:title>No element disallowed derivation</sch:title>
+ <sch:rule context="xs:element">
+   <sch:assert test="empty(@final)">Rule 9-44: 
+     An element xs:element MUST NOT have an attribute {}final.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-45"><sch:title>No element default value</sch:title>
+ <sch:rule context="xs:element">
+   <sch:assert test="empty(@default)"
+     >Rule 9-45: An element xs:element MUST NOT have an attribute {}default.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-46"><sch:title>No element fixed value</sch:title>
+ <sch:rule context="xs:element">
+   <sch:assert test="empty(@fixed)"
+     >Rule 9-46: An element xs:element MUST NOT have an attribute {}fixed.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-47"><sch:title>Element declaration is nillable</sch:title>
+ <sch:rule context="xs:element[@name and (empty(@abstract)
+                                          or xs:boolean(@abstract) = false())]">
+   <sch:assert test="exists(@nillable)
+                     and xs:boolean(@nillable) = true()"
+     >Rule 9-47: An element declaration MUST have the {nillable} property with a value of true.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-48"><sch:title>Attribute declaration is top-level</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:assert test="exists(parent::xs:schema)"
+     >Rule 9-48: An attribute declaration MUST be top-level.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-49"><sch:title>Attribute declaration has data definition</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-49: An attribute declaration MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-50"><sch:title>Attribute declaration has type</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:assert test="exists(@type)"
+     >Rule 9-50: A top-level attribute declaration MUST have a type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-51"><sch:title>No attribute type of xs:ID</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:ID')"
+     >Rule 9-51: A schema component MUST NOT have an attribute {}type with a value of xs:ID.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-52"><sch:title>No attribute type of xs:IDREF</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:IDREF')"
+     >Rule 9-52: A schema component MUST NOT have an attribute {}type with a value of xs:IDREF.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-53"><sch:title>No attribute type of xs:IDREFS</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:IDREFS')"
+     >Rule 9-53: A schema component MUST NOT have an attribute {}type with a value of xs:IDREFS.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-54"><sch:title>No attribute type of xs:ENTITY</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:ENTITY')"
+     >Rule 9-54: A schema component MUST NOT have an attribute {}type with a value of xs:ENTITY.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-55"><sch:title>No attribute type of xs:ENTITIES</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:ENTITIES')"
+     >Rule 9-55: A schema component MUST NOT have an attribute {}type with a value of xs:ENTITIES.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-56"><sch:title>No attribute type of xs:anySimpleType</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:anySimpleType')"
+     >Rule 9-56: A schema component MUST NOT have an attribute {}type with a value of xs:anySimpleType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-57"><sch:title>No attribute default values</sch:title>
+ <sch:rule context="xs:attribute">
+   <sch:assert test="empty(@default)"
+     >Rule 9-57: An element xs:attribute MUST NOT have an attribute {}default.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-58"><sch:title>No fixed values for optional attributes</sch:title>
+ <sch:rule context="xs:attribute[exists(@ref) and @use eq 'required']">
+   <sch:report test="false()" role="warning">This rule does not constrain attribute uses that are required</sch:report>
+ </sch:rule>
+ <sch:rule context="xs:attribute">
+   <sch:assert test="empty(@fixed)"
+     >Rule 9-58: An element xs:attribute that is not a required attribute use MUST NOT have an attribute {}fixed.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-59"><sch:title>No use of element xs:notation</sch:title>
+ <sch:rule context="xs:notation">
+   <sch:assert test="false()"
+     >Rule 9-59: The schema MUST NOT contain the element xs:notation.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-61"><sch:title>No xs:all</sch:title>
+ <sch:rule context="xs:all">
+   <sch:assert test="false()"
+     >Rule 9-61: The schema MUST NOT contain the element xs:all</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-62"><sch:title>xs:sequence must be child of xs:extension</sch:title>
+ <sch:rule context="xs:sequence">
+   <sch:assert test="exists(parent::xs:extension)"
+     >Rule 9-62: An element xs:sequence MUST be a child of element xs:extension.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-64"><sch:title>No xs:choice</sch:title>
+ <sch:rule context="xs:choice">
+   <sch:assert test="false()"
+     >Rule 9-64: The schema MUST NOT contain the element xs:choice</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-66"><sch:title>Sequence has minimum cardinality 1</sch:title>
+ <sch:rule context="xs:sequence">
+   <sch:assert test="empty(@minOccurs) or xs:integer(@minOccurs) = 1"
+     >Rule 9-66: An element xs:sequence MUST either not have the attribute {}minOccurs, or that attribute MUST have a value of 1.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-67"><sch:title>Sequence has maximum cardinality 1</sch:title>
+ <sch:rule context="xs:sequence">
+   <sch:assert test="empty(@maxOccurs) or (@maxOccurs instance of xs:integer
+                                           and 1 = xs:integer(@maxOccurs))"
+     >Rule 9-67: An element xs:sequence MUST either not have the attribute {}maxOccurs, or that attribute MUST have a value of 1.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-70"><sch:title>No use of xs:any</sch:title>
+ <sch:rule context="xs:any">
+   <sch:assert test="false()"
+     >Rule 9-70: The schema MUST NOT contain the element xs:any.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-71"><sch:title>No use of xs:anyAttribute</sch:title>
+ <sch:rule context="xs:anyAttribute">
+   <sch:assert test="false()"
+     >Rule 9-71: The schema MUST NOT contain the element xs:anyAttribute.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-72"><sch:title>No use of xs:unique</sch:title>
+ <sch:rule context="xs:unique">
+   <sch:assert test="false()"
+     >Rule 9-72: The schema MUST NOT contain the element xs:unique.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-73"><sch:title>No use of xs:key</sch:title>
+ <sch:rule context="xs:key">
+   <sch:assert test="false()"
+     >Rule 9-73: The schema MUST NOT contain the element xs:key.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-74"><sch:title>No use of xs:keyref</sch:title>
+ <sch:rule context="xs:keyref">
+   <sch:assert test="false()"
+     >Rule 9-74: The schema MUST NOT contain the element xs:keyref.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-75"><sch:title>No use of xs:group</sch:title>
+ <sch:rule context="xs:group">
+   <sch:assert test="false()"
+     >Rule 9-75: The schema MUST NOT contain the element xs:group.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-76"><sch:title>No definition of attribute groups</sch:title>
+ <sch:rule context="xs:attributeGroup[@name]">
+   <sch:assert test="false()"
+     >Rule 9-76: The schema MUST NOT contain an attribute group definition schema component.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-77"><sch:title>Comment is not recommended</sch:title>
+ <sch:rule context="node()[comment()]">
+   <sch:report test="true()" role="warning"
+     >An XML Comment is not an XML Schema annotation component; an XML comment SHOULD NOT appear in the schema.</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-78"><sch:title>Documentation element has no element children</sch:title>
+ <sch:rule context="xs:documentation/node()">
+   <sch:assert test="self::text() or self::comment()"
+     >Rule 9-78: A child of element xs:documentation MUST be text or an XML comment.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-79"><sch:title>xs:appinfo children are comments, elements, or whitespace</sch:title>
+ <sch:rule context="xs:appinfo/node()">
+   <sch:assert test="self::comment()
+                     or self::element()
+                     or self::text()[string-length(normalize-space(.)) = 0]"
+     >Rule 9-79: A child of element xs:appinfo MUST be an element, a comment, or whitespace text.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-80"><sch:title>Appinfo child elements have namespaces</sch:title>
+ <sch:rule context="xs:appinfo/*">
+   <sch:assert test="namespace-uri() != xs:anyURI('')"
+     >Rule 9-80: An element that is a child of xs:appinfo MUST have a namespace name.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-81"><sch:title>Appinfo descendants are not XML Schema elements</sch:title>
+ <sch:rule context="xs:appinfo//xs:*">
+   <sch:assert test="false()"
+     >Rule 9-81: An element with a namespace name of xs: MUST NOT have an ancestor element xs:appinfo.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-82"><sch:title>Schema has data definition</sch:title>
+ <sch:rule context="xs:schema">
+   <sch:assert test="some $definition in (xs:annotation/xs:documentation)[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-82: An element xs:schema MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-83"><sch:title>Schema document defines target namespace</sch:title>
+ <sch:rule context="xs:schema">
+   <sch:assert test="exists(@targetNamespace)"
+     >Rule 9-83: The schema MUST define a target namespace.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-85"><sch:title>Schema has version</sch:title>
+ <sch:rule context="xs:schema">
+   <sch:assert test="some $version in @version satisfies
+                     string-length(normalize-space(@version)) &gt; 0"
+       >Rule 9-85: An element xs:schema MUST have an attribute {}version that MUST NOT be empty.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-86"><sch:title>No disallowed substitutions</sch:title>
+ <sch:rule context="xs:schema">
+   <sch:assert test="empty(@blockDefault)"
+     >Rule 9-86: An element xs:schema MUST NOT have an attribute {}blockDefault.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-87"><sch:title>No disallowed derivations</sch:title>
+ <sch:rule context="xs:schema">
+   <sch:assert test="empty(@finalDefault)"
+     >Rule 9-87: An element xs:schema MUST NOT have an attribute {}finalDefault.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-88"><sch:title>No use of xs:redefine</sch:title>
+ <sch:rule context="xs:redefine">
+   <sch:assert test="false()"
+     >Rule 9-88: The schema MUST NOT contain the element xs:redefine.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-89"><sch:title>No use of xs:include</sch:title>
+ <sch:rule context="xs:include">
+   <sch:assert test="false()"
+     >Rule 9-89: The schema MUST NOT contain the element xs:include.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-90"><sch:title>xs:import must have namespace</sch:title>
+ <sch:rule context="xs:import">
+   <sch:assert test="exists(@namespace)"
+     >Rule 9-90: An element xs:import MUST have an attribute {}namespace.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-92"><sch:title>Namespace referenced by attribute type is imported</sch:title>
+ <sch:rule context="xs:*[@type]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@type, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or $namespace = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace])"
+               >Rule 9-92: The namespace of a type referenced by @type MUST be the target namespace, the XML Schema namespace, or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-93"><sch:title>Namespace referenced by attribute base is imported</sch:title>
+ <sch:rule context="xs:*[@base]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@base, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or $namespace = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace])"
+               >Rule 9-93: The namespace of a type referenced by @base MUST be the target namespace, the XML Schema namespace, or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-94"><sch:title>Namespace referenced by attribute itemType is imported</sch:title>
+ <sch:rule context="xs:*[@itemType]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@itemType, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or $namespace = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace])"
+               >Rule 9-94: The namespace of a type referenced by @itemType MUST be the target namespace, the XML Schema namespace, or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-95"><sch:title>Namespaces referenced by attribute memberTypes is imported</sch:title>
+ <sch:rule context="xs:*[@memberTypes]">
+   <sch:assert test="every $type in tokenize(normalize-space(@memberTypes), ' '),
+                           $namespace in namespace-uri-from-QName(resolve-QName($type, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or $namespace = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace])"
+               >Rule 9-95: The namespace of a type referenced by @memberTypes MUST be the target namespace, the XML Schema namespace, or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-96"><sch:title>Namespace referenced by attribute ref is imported</sch:title>
+ <sch:rule context="xs:*[@ref]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies
+                       $namespace = nf:get-target-namespace(.)
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace]"
+               >Rule 9-96: The namespace of a component referenced by @ref MUST be the target namespace or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-97"><sch:title>Namespace referenced by attribute substitutionGroup is imported</sch:title>
+ <sch:rule context="xs:*[@substitutionGroup]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@substitutionGroup, .)) satisfies
+                       $namespace = nf:get-target-namespace(.)
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace]"
+               >Rule 9-97: The namespace of a component referenced by @substitutionGroup MUST be the target namespace or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-2"><sch:title>Object type with complex content is derived from structures:ObjectType</sch:title>
+ <sch:rule context="xs:complexType[exists(xs:complexContent)
+                                   and not(ends-with(@name, 'AssociationType')
+                                       or ends-with(@name, 'MetadataType')
+                                       or ends-with(@name, 'AugmentationType'))]">
+   <sch:assert test="
+       every $derivation-method in (xs:complexContent/xs:extension, xs:complexContent/xs:restriction),
+             $base in $derivation-method/@base,
+             $base-qname in resolve-QName($base, $derivation-method),
+             $base-local-name in local-name-from-QName($base-qname) satisfies (
+         $base-qname = xs:QName('structures:ObjectType')
+         or not(ends-with($base-local-name, 'AssociationType')
+                or ends-with($base-local-name, 'AugmentationType')))"
+     >Rule 10-2: An object type with complex content MUST be derived from structures:ObjectType or from another object type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-7"><sch:title>Import of external namespace has data definition</sch:title>
+ <sch:rule context="xs:import[@appinfo:externalImportIndicator]">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 10-7: An element xs:import that is annotated as importing an external schema document MUST be a documented component.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-9"><sch:title>Structure of external adapter type definition follows pattern</sch:title>
+ <sch:rule context="xs:complexType[@appinfo:externalAdapterTypeIndicator]">
+   <sch:assert test="xs:complexContent/xs:extension[
+                       resolve-QName(@base, .) = xs:QName('structures:ObjectType')
+                     ]/xs:sequence"
+     >Rule 10-9: An external adapter type definition MUST be a complex type definition with complex content that extends structures:ObjectType, and that uses xs:sequence as its top-level compositor.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-10"><sch:title>Element use from external adapter type defined by external schema documents</sch:title>
+ <sch:rule context="xs:element[@ref
+                               and exists(ancestor::xs:complexType[exists(@appinfo:externalAdapterTypeIndicator)])]">
+   <sch:assert test="some $ref-namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies
+                       nf:get-document-element(.)/xs:import[
+                         $ref-namespace = xs:anyURI(@namespace)
+                         and @appinfo:externalImportIndicator]"
+     >Rule 10-10: An element reference that appears within an external adapter type MUST have a target namespace that is imported as external.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-11"><sch:title>External adapter type not a base type</sch:title>
+ <sch:rule context="xs:*[(self::xs:extension or self::xs:restriction)
+                         and (some $base-qname in resolve-QName(@base, .),
+                                   $base-namespace in namespace-uri-from-QName($base-qname) satisfies
+                                nf:get-target-namespace(.) = $base-namespace)]">
+   <sch:assert test="nf:resolve-type(., resolve-QName(@base, .))[
+                       empty(@appinfo:externalAdapterTypeIndicator)]"
+      >Rule 10-11: An external adapter type definition MUST NOT be a base type definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-13"><sch:title>External attribute use only in external adapter type</sch:title>
+ <sch:rule context="xs:attribute[some $ref-namespace in namespace-uri-from-QName(resolve-QName(@ref, .)),
+                                      $import in ancestor::xs:schema[1]/xs:import satisfies (
+                                   xs:anyURI($import/@namespace) = $ref-namespace
+                                   and exists($import/@appinfo:externalImportIndicator))]">
+   <sch:assert test="exists(ancestor::xs:complexType[1]/@appinfo:externalAdapterTypeIndicator)"
+     >Rule 10-13: An external attribute use MUST be in an external adapter type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-14"><sch:title>External attribute use has data definition</sch:title>
+ <sch:rule context="xs:attribute[some $ref-namespace in namespace-uri-from-QName(resolve-QName(@ref, .)),
+                                      $import in ancestor::xs:schema[1]/xs:import satisfies (
+                                   xs:anyURI($import/@namespace) = $ref-namespace
+                                   and exists(@appinfo:externalImportIndicator))]">
+   <sch:assert test="some $documentation in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($documentation))) &gt; 0"
+     >Rule 10-14: An external attribute use MUST be a documented component with a non-empty data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-16"><sch:title>External element use has data definition</sch:title>
+ <sch:rule context="xs:element[
+     some $ref-namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies
+       nf:get-document-element(.)/self::xs:schema//xs:import[
+         xs:anyURI(@namespace) = $ref-namespace
+         and @appinfo:externalImportIndicator]]">
+   <sch:assert test="some $documentation in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($documentation))) &gt; 0"
+     >Rule 10-16: An external attribute use MUST be a documented component with a non-empty data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-17"><sch:title>Name of code type ends in "CodeType"</sch:title>
+ <sch:rule context="xs:complexType[exists(xs:simpleContent[
+                      exists(xs:*[local-name() = ('extension', 'restriction')
+                                  and (ends-with(@base, 'CodeSimpleType')
+                                  or ends-with(@base, 'CodeType'))])])]">
+   <sch:report role="warning"
+       test="not(ends-with(@name, 'CodeType'))"
+     >A complex type definition with a {base type definition} of a code type or code simple type SHOULD have a {name} that ends in 'CodeType'.</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-19"><sch:title>Element of code type has code representation term</sch:title>
+ <sch:rule context="xs:element[exists(@name) and exists(@type) and ends-with(@type, 'CodeType')]">
+   <sch:report role="warning"
+       test="not(ends-with(@name, 'Code'))"
+     >An element with a type that is a code type SHOULD have a name with representation term "Code"</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-20"><sch:title>Proxy type has designated structure</sch:title>
+ <sch:rule context="xs:complexType[some $name in @name,
+                                   $extension in xs:simpleContent/xs:extension,
+                                   $base-qname in resolve-QName($extension/@base, $extension) satisfies
+                                   $base-qname = QName('http://www.w3.org/2001/XMLSchema', $name)]">
+   <sch:assert test="xs:simpleContent[
+                       xs:extension[
+                         empty(xs:attribute)
+                         and count(xs:attributeGroup) = 1
+                         and xs:attributeGroup[
+                               resolve-QName(@ref, .) = xs:QName('structures:SimpleObjectAttributeGroup')]]]"
+     >Rule 10-20: A proxy type MUST have the designated structure. It MUST use xs:extension. It MUST NOT use xs:attribute. It MUST include exactly one xs:attributeGroup reference, which must be to structures:SimpleObjectAttributeGroup.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-21"><sch:title>Association type derived from structures:AssociationType</sch:title>
+ <sch:rule context="xs:complexType">
+   <sch:let name="is-association-type" value="exists(@name[ends-with(., 'AssociationType')])"/>
+   <sch:let name="has-association-base-type" value="
+     exists(xs:complexContent[
+       exists(xs:*[local-name() = ('extension', 'restriction')
+                   and exists(@base[ends-with(., 'AssociationType')])])])"/>
+   <sch:assert test="$is-association-type = $has-association-base-type"
+     >Rule 10-21: A type MUST have an association type name if and only if it is derived from an association type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-22"><sch:title>Association element type is an association type</sch:title>
+ <sch:rule context="xs:element[exists(@name)]">
+   <sch:assert test="exists(@type[ends-with(., 'AssociationType')])
+                     = exists(@name[ends-with(., 'Association')])"
+     >Rule 10-22: An element MUST have a name that ends in 'Association' if and only if it has a type that is an association type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-23"><sch:title>Augmentable type has augmentation point element</sch:title>
+ <sch:rule context="xs:complexType[
+                      @name[not(ends-with(., 'MetadataType'))
+                            and not(ends-with(., 'AugmentationType'))]
+                      and empty(@appinfo:externalAdapterTypeIndicator)
+                      and xs:complexContent]">
+   <sch:let name="augmentation-point-qname"
+            value="QName(string(nf:get-target-namespace(.)),
+                         replace(./@name, 'Type$', 'AugmentationPoint'))"/>
+   <sch:assert test="xs:complexContent/xs:extension/xs:sequence/xs:element[
+                       @ref[resolve-QName(., ..) = $augmentation-point-qname]]"
+     >Rule 10-23: An augmentable type MUST contain an element use of its corresponding augmentation point element.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-24"><sch:title>Augmentable type has at most one augmentation point element</sch:title>
+ <sch:rule context="xs:complexType[
+                      @name[not(ends-with(., 'MetadataType'))
+                            and not(ends-with(., 'AugmentationType'))]
+                      and empty(@appinfo:externalAdapterTypeIndicator)
+                      and xs:complexContent]">
+   <sch:let name="augmentation-point-qname"
+            value="QName(string(nf:get-target-namespace(.)),
+                         replace(./@name, 'Type$', 'AugmentationPoint'))"/>
+   <sch:assert test="count(xs:complexContent/xs:extension/xs:sequence/xs:element[
+                             @ref[resolve-QName(., ..) = $augmentation-point-qname]]) le 1"
+     >Rule 10-24: An augmentable type MUST contain no more than one element use of its corresponding augmentation point element.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-25"><sch:title>Augmentation point element corresponds to its base type</sch:title>
+ <sch:rule context="xs:element[exists(@name[
+                                matches(., 'AugmentationPoint$')])]">
+   <sch:let name="element-name" value="@name"/>
+   <sch:assert test="exists(
+                       parent::xs:schema/xs:complexType[
+                         @name = replace($element-name, 'AugmentationPoint$', 'Type')
+                         and exists(@name[
+                                 not(ends-with(., 'MetadataType'))
+                                 and not(ends-with(., 'AugmentationType'))])
+                               and empty(@appinfo:externalAdapterTypeIndicator)
+                               and exists(child::xs:complexContent)])"
+     >Rule 10-25: A schema document containing an element declaration for an augmentation point element MUST also contain a type definition for its base type, a corresponding augmentable type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-26"><sch:title>An augmentation point element has no type</sch:title>
+ <sch:rule context="xs:element[exists(@name[
+                                matches(., 'AugmentationPoint$')])]">
+   <sch:assert test="empty(@type)"
+       >Rule 10-26: An augmentation point element MUST have no type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-27"><sch:title>An augmentation point element has no substitution group</sch:title>
+ <sch:rule context="xs:element[exists(@name[
+                                matches(., 'AugmentationPoint$')])]">
+   <sch:assert test="empty(@substitutionGroup)"
+       >Rule 10-27: An augmentation point element MUST have no substitution group.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-28"><sch:title>Augmentation point element is only referenced by its base type</sch:title>
+ <sch:rule context="xs:complexType//xs:element[exists(@ref[
+                      matches(local-name-from-QName(resolve-QName(., ..)), 'AugmentationPoint$')]) ]">
+   <sch:assert test="QName(string(nf:get-target-namespace(ancestor::xs:complexType[1])), ancestor::xs:complexType[1]/@name)
+                     = QName(string(namespace-uri-from-QName(resolve-QName(@ref, .))),
+                         replace(local-name-from-QName(resolve-QName(@ref, .)), 'AugmentationPoint$', 'Type'))"
+     >Rule 10-28: An augmentation point element MUST only be referenced by its base type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-29"><sch:title>Augmentation point element use is optional</sch:title>
+ <sch:rule context="xs:complexType//xs:element[exists(@ref[
+                          matches(local-name-from-QName(resolve-QName(., ..)), 'AugmentationPoint$')]) ]">
+   <sch:assert test="exists(@minOccurs) and xs:integer(@minOccurs) = 0"
+       >Rule 10-29: An augmentation point element particle MUST have attribute minOccurs equal to 0.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-30"><sch:title>Augmentation point element use is unbounded</sch:title>
+ <sch:rule context="xs:complexType//xs:element[exists(@ref[
+                          matches(local-name-from-QName(resolve-QName(., ..)), 'AugmentationPoint$')]) ]">
+   <sch:assert test="exists(@maxOccurs) and string(@maxOccurs) = 'unbounded'"
+      >Rule 10-30: An augmentation point element particle MUST have attribute maxOccurs set to unbounded.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-31"><sch:title>Augmentation point element use must be last element in its base type</sch:title>
+ <sch:rule context="xs:complexType//xs:element[exists(@ref[
+                          matches(local-name-from-QName(resolve-QName(., ..)), 'AugmentationPoint$')]) ]">
+   <sch:assert test="empty(following-sibling::*)"
+      >Rule 10-31: An augmentation point element particle MUST be the last element occurrence in its content model.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-34"><sch:title>Schema component with name ending in "AugmentationType" is an augmentation type</sch:title>
+ <sch:rule context="xs:*[ends-with(@name, 'AugmentationType')]">
+   <sch:assert test="self::xs:complexType/xs:complexContent/xs:*[
+                       (self::xs:extension or self::xs:restriction)
+                       and ends-with(@base, 'AugmentationType')]"
+      >Rule 10-34: An augmentation type definition schema component with {name} ending in 'AugmentationType' MUST be an augmentation type definition that is a complex type definition with complex content that extends or restricts an augmentation type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-35"><sch:title>Type derived from structures:AugmentationType is an augmentation type</sch:title>
+ <sch:rule context="xs:*[(self::xs:restriction or self::xs:extension)
+                         and ends-with(@base, 'AugmentationType')]">
+   <sch:assert test="ancestor::xs:complexType[ends-with(@name, 'AugmentationType')]"
+               >Rule 10-35: A type definition derived from an augmentation type MUST be an augmentation type definition</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-36"><sch:title>Augmentation element type is an augmentation type</sch:title>
+ <sch:rule context="xs:element[exists(@name)]">
+   <sch:assert test="exists(@type[ends-with(., 'AugmentationType')])
+                     = exists(@name[ends-with(., 'Augmentation')])"
+     >Rule 10-36: An element declaration MUST have a name that ends in "Augmentation" if and only if it has a type that is an augmentation type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-42"><sch:title>Name of element that ends in "Representation" is abstract</sch:title>
+ <sch:rule context="xs:element[@name[ends-with(., 'Representation')]]">
+   <sch:report role="warning"
+       test="empty(@abstract) or xs:boolean(@abstract) = false()"
+     >An element declaration with a name that ends in 'Representation' SHOULD have the {abstract} property with a value of "true".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-45"><sch:title>Schema component name has xml:lang</sch:title>
+ <sch:rule context="xs:*[exists(@name)]">
+   <sch:let name="xml-lang-attribute" value="ancestor-or-self::*[exists(@xml:lang)][1]/@xml:lang"/>
+   <sch:assert test="exists($xml-lang-attribute)
+                     and string-length(normalize-space($xml-lang-attribute)) gt 0"
+               >Rule 10-45: The name of an XML Schema component defined by the schema MUST be in the scope of an occurrence of attribute xml:lang that has a value that is not empty.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-46"><sch:title>Schema component names have only specific characters</sch:title>
+ <sch:rule context="xs:*[exists(@name)]">
+   <sch:assert test="matches(@name, '^[A-Za-z0-9\-_\.]*$')"
+     >Rule 10-46: The name of an XML Schema component defined by the schema must be composed of only the characters uppercase 'A' through 'Z', lowercase 'a' through 'z', numbers '0' through '9', underscore, hyphen, and period.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-49"><sch:title>Attribute name begins with lower case letter</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:assert test="matches(@name, '^[a-z]')"
+     >Rule 10-49: Within the schema, any attribute declaration MUST have a name that begins with a lowercase letter
+     ('a'-'z').</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-50"><sch:title>Name of schema component other than attribute and proxy type begins with upper case letter</sch:title>
+ <sch:rule context="xs:attribute">
+   <sch:report test="false()" role="warning">This rule does not apply to an attribute.</sch:report>
+ </sch:rule>
+ <sch:rule context="xs:complexType[some $name in @name,
+                                   $extension in xs:simpleContent/xs:extension,
+                                   $base-qname in resolve-QName($extension/@base, $extension) satisfies
+                                   $base-qname = QName('http://www.w3.org/2001/XMLSchema', $name)]">
+   <sch:report test="false()" role="warning">This rule does not apply to a proxy types.</sch:report>
+ </sch:rule>
+ <sch:rule context="xs:*[exists(@name)]">
+   <sch:assert test="matches(@name, '^[A-Z]')"
+     >Rule 10-50: Within the schema, an XML Schema component that is not an attribute declaration or proxy type MUST have a name that begins with an upper-case letter ('A'-'Z').</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-69"><sch:title>Deprecated annotates schema component</sch:title>
+ <sch:rule context="*[exists(@appinfo:deprecated)]">
+   <sch:assert test="namespace-uri-from-QName(node-name(.)) = xs:anyURI('http://www.w3.org/2001/XMLSchema')"
+           >Rule 10-69: The attribute appinfo:deprecated MUST be owned by an element with a namespace name http://www.w3.org/2001/XMLSchema.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-70"><sch:title>External import indicator annotates import</sch:title>
+ <sch:rule context="*[exists(@appinfo:externalImportIndicator)]">
+   <sch:assert test="exists(self::xs:import)"
+       >Rule 10-70: The attribute {https://docs.oasis-open.org/niemopen/ns/model/appinfo/6.0/}externalImportIndicator MUST be owned by an element xs:import.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-71"><sch:title>External adapter type indicator annotates complex type</sch:title>
+ <sch:rule context="*[exists(@appinfo:externalAdapterTypeIndicator)]">
+   <sch:assert test="exists(self::xs:complexType)"
+           >Rule 10-71: The attribute appinfo:externalAdapterTypeIndicator MUST be owned by an element xs:complexType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-76"><sch:title>appinfo:LocalTerm annotates schema</sch:title>
+ <sch:rule context="appinfo:LocalTerm">
+   <sch:assert test="parent::xs:appinfo[parent::xs:annotation[parent::xs:schema]]"
+     >Rule 10-76: The element appinfo:LocalTerm MUST be application information on an element xs:schema.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-77"><sch:title>appinfo:LocalTerm has literal or definition</sch:title>
+ <sch:rule context="appinfo:LocalTerm">
+   <sch:assert test="exists(@literal) or exists(@definition)"
+           >Rule 10-77: The element {https://docs.oasis-open.org/niemopen/ns/model/appinfo/6.0/}LocalTerm MUST have a literal or definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-1"><sch:title>Name of type ends in "Type"</sch:title>
+ <sch:rule context="xs:complexType[some $name in @name,
+                                   $extension in xs:simpleContent/xs:extension,
+                                   $base-qname in resolve-QName($extension/@base, $extension) satisfies
+                                   $base-qname = QName('http://www.w3.org/2001/XMLSchema', $name)]">
+   <sch:report test="false()" role="warning">The name of a proxy type does not end in "Type".</sch:report>
+ </sch:rule>
+ <sch:rule context="xs:*[(self::xs:simpleType or self::xs:complexType) and exists(@name)]">
+   <sch:assert test="ends-with(@name, 'Type')"
+     >Rule 11-1: A type definition schema component that does not define a proxy type MUST have a name that ends in "Type".</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-2"><sch:title>Only types have name ending in "Type" or "SimpleType"</sch:title>
+ <sch:rule context="xs:*[exists(@name) and ends-with(@name, 'SimpleType')]">
+   <sch:assert test="local-name() = 'simpleType'"
+               >Rule 11-2: A schema component with a name that ends in 'SimpleType' MUST be a simple type definition.</sch:assert>
+ </sch:rule>
+ <sch:rule context="xs:*[exists(@name) and ends-with(@name, 'Type')]">
+   <sch:assert test="local-name() = 'complexType'"
+               >A schema component with a name that ends in 'Type' and does not end in 'SimpleType' MUST be a complex type definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-3"><sch:title>Base type definition defined by conformant schema</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="some $base-namespace in namespace-uri-from-QName(resolve-QName(@base, .)) satisfies (
+                       $base-namespace = (nf:get-target-namespace(.), xs:anyURI('http://www.w3.org/2001/XMLSchema'))
+                       or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                                                  and $base-namespace = xs:anyURI(@namespace)
+                                                                  and empty(@appinfo:externalImportIndicator)]))"
+     >Rule 11-3: The {base type definition} of a type definition MUST have the target namespace or the XML Schema namespace or a namespace that is imported as conformant.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-4"><sch:title>Name of simple type ends in "SimpleType"</sch:title>
+ <sch:rule context="xs:simpleType[@name]">
+   <sch:assert test="ends-with(@name, 'SimpleType')"
+     >Rule 11-4: A simple type definition schema component MUST have a name that ends in "SimpleType".</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-6"><sch:title>List item type defined by conformant schemas</sch:title>
+ <sch:rule context="xs:list[exists(@itemType)]">
+   <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@itemType, .))"/>
+   <sch:assert test="$namespace = (nf:get-target-namespace(.), xs:anyURI('http://www.w3.org/2001/XMLSchema'))
+                     or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                   and $namespace = xs:anyURI(@namespace)
+                                   and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-6: The item type of a list simple type definition MUST have a target namespace equal to the target namespace of the XML Schema document within which it is defined, or a namespace that is imported as conformant by the schema document within which it is defined.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-7"><sch:title>Union member types defined by conformant schemas</sch:title>
+ <sch:rule context="xs:union[exists(@memberTypes)]">
+   <sch:assert test="every $qname in tokenize(normalize-space(@memberTypes), ' '),
+                           $namespace in namespace-uri-from-QName(resolve-QName($qname, .))
+                     satisfies ($namespace = nf:get-target-namespace(.)
+                                or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                          and $namespace = xs:anyURI(@namespace)
+                                          and empty(@appinfo:externalImportIndicator)]))"
+               >Rule 11-7: Every member type of a union simple type definition MUST have a target namespace that is equal to either the target namespace of the XML Schema document within which it is defined or a namespace that is imported as conformant by the schema document within which it is defined.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-8"><sch:title>Name of a code simple type ends in "CodeSimpleType"</sch:title>
+ <sch:rule context="xs:simpleType[exists(@name)
+     and (xs:restriction/xs:enumeration
+          or xs:restriction[ends-with(local-name-from-QName(resolve-QName(@base, .)), 'CodeSimpleType')])]">
+   <sch:report test="not(ends-with(@name, 'CodeSimpleType'))" role="warning"
+     >A simple type definition schema component that has an enumeration facet or that is derived from a code simple type SHOULD have a name that ends in "CodeSimpleType".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-10"><sch:title>Attribute of code simple type has code representation term</sch:title>
+ <sch:rule context="xs:attribute[exists(@name) and exists(@type) and ends-with(@type, 'CodeSimpleType')]">
+   <sch:report test="not(ends-with(@name, 'Code'))" role="warning"
+     >An attribute with a type that is a code simple type SHOULD have a name with representation term "Code"</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-11"><sch:title>Complex type with simple content has structures:SimpleObjectAttributeGroup</sch:title>
+ <sch:rule context="xs:simpleContent/xs:extension[
+     some $base-qname in resolve-QName(@base, .) satisfies
+       namespace-uri-from-QName($base-qname) = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+       or ends-with(local-name-from-QName($base-qname), 'SimpleType')]">
+   <sch:assert test="xs:attributeGroup[
+                       resolve-QName(@ref, .) = xs:QName('structures:SimpleObjectAttributeGroup')]"
+     >Rule 11-11: A complex type definition with simple content schema component with a derivation method of extension that has a base type definition that is a simple type MUST incorporate the attribute group {https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/}SimpleObjectAttributeGroup.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-12"><sch:title>Element type does not have a simple type name</sch:title>
+ <sch:rule context="xs:element[exists(@type)]">
+   <sch:assert test="not(ends-with(@type, 'SimpleType'))"
+               >Rule 11-12: The {type definition} of an element declaration MUST NOT have a {name} that ends in 'SimpleType'.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-13"><sch:title>Element type is from conformant namespace</sch:title>
+ <sch:rule context="xs:element[exists(@type)]">
+   <sch:assert test="for $type-qname in resolve-QName(@type, .),
+                         $type-namespace in namespace-uri-from-QName($type-qname) return
+                       $type-namespace = nf:get-target-namespace(.)
+                       or exists(nf:get-document-element(.)/xs:import[
+                                   xs:anyURI(@namespace) = $type-namespace
+                                   and empty(@appinfo:externalImportIndicator)])"
+               >Rule 11-13: The {type definition} of an element declaration MUST have a {target namespace} that is the target namespace, or one that is imported as conformant.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-14"><sch:title>Name of element that ends in "Abstract" is abstract</sch:title>
+ <sch:rule context="xs:element[@name]">
+   <sch:report role="warning"
+       test="not(exists(@abstract[xs:boolean(.) = true()])
+                 eq (ends-with(@name, 'Abstract')
+                     or ends-with(@name, 'AugmentationPoint')
+                     or ends-with(@name, 'Representation')))"
+     >An element declaration SHOULD have a name that ends in 'Abstract', 'AugmentationPoint', or 'Representation' if and only if it has the {abstract} property with a value of "true".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-15"><sch:title>Name of element declaration with simple content has representation term</sch:title>
+ <sch:rule context="xs:element[@name and @type
+                               and (some $type-qname in resolve-QName(@type, .) satisfies (
+                                      nf:get-target-namespace(.) = namespace-uri-from-QName($type-qname)
+                                      and nf:resolve-type(., $type-qname)/xs:simpleContent))]">
+   <sch:report role="warning"
+       test="every $representation-term
+             in ('Amount', 'BinaryObject', 'Graphic', 'Picture', 'Sound', 'Video', 'Code', 'DateTime', 'Date', 'Time', 'Duration', 'ID', 'URI', 'Indicator', 'Measure', 'Numeric', 'Value', 'Rate', 'Percent', 'Quantity', 'Text', 'Name', 'List')
+             satisfies not(ends-with(@name, $representation-term))"
+     >The name of an element declaration that is of simple content SHOULD use a representation term.</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-17"><sch:title>Element substitution group defined by conformant schema</sch:title>
+ <sch:rule context="xs:element[exists(@substitutionGroup)]">
+   <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@substitutionGroup, .))"/>
+   <sch:assert test="$namespace = nf:get-target-namespace(.)
+                     or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                   and $namespace = xs:anyURI(@namespace)
+                                   and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-17: An element substitution group MUST have either the target namespace or a namespace that is imported as conformant.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-18"><sch:title>Attribute type defined by conformant schema</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@type, .))"/>
+   <sch:assert test="$namespace = (nf:get-target-namespace(.), xs:anyURI('http://www.w3.org/2001/XMLSchema'))
+                     or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                   and $namespace = xs:anyURI(@namespace)
+                                   and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-18: The type of an attribute declaration MUST have the target namespace or the XML Schema namespace or a namespace that is imported as conformant.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-19"><sch:title>Attribute name uses representation term</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:report role="warning"
+       test="every $representation-term
+             in ('Amount', 'BinaryObject', 'Graphic', 'Picture', 'Sound', 'Video', 'Code', 'DateTime', 'Date', 'Time', 'Duration', 'ID', 'URI', 'Indicator', 'Measure', 'Numeric', 'Value', 'Rate', 'Percent', 'Quantity', 'Text', 'Name', 'List')
+             satisfies not(ends-with(@name, $representation-term))"
+     >An attribute name SHOULD end with a representation term.</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-21"><sch:title>Element reference defined by conformant schema</sch:title>
+ <sch:rule context="xs:element[exists(ancestor::xs:complexType[empty(@appinfo:externalAdapterTypeIndicator)]) and @ref]">
+   <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@ref, .))"/>
+   <sch:assert test="$namespace = nf:get-target-namespace(.)
+                     or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                   and $namespace = xs:anyURI(@namespace)
+                                   and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-21: An element reference MUST be to a component that has a namespace that is either the target namespace of the schema document in which it appears, or which is imported as conformant by that schema document.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-22"><sch:title>Referenced attribute defined by conformant schemas</sch:title>
+  <sch:rule context="xs:attribute[@ref]">
+     <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@ref, .))"/>
+     <sch:assert test="some $namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or ancestor::xs:schema[1]/xs:import[
+                            @namespace
+                            and $namespace = xs:anyURI(@namespace)
+                            and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-22: An attribute {}ref MUST have the target namespace or a namespace that is imported as conformant.     </sch:assert>
+  </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-23"><sch:title>Schema uses only known attribute groups</sch:title>
+  <sch:rule context="xs:attributeGroup[@ref]">
+    <sch:assert test="some $ref in resolve-QName(@ref, .) satisfies (
+                        $ref = xs:QName('structures:SimpleObjectAttributeGroup'))"
+      >Rule 11-23: An attribute group reference MUST be structures:SimpleObjectAttributeGroup</sch:assert>
+  </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-30"><sch:title>xs:documentation has xml:lang</sch:title>
+ <sch:rule context="xs:documentation">
+   <sch:let name="xml-lang-attribute" value="ancestor-or-self::*[exists(@xml:lang)][1]/@xml:lang"/>
+   <sch:assert test="exists($xml-lang-attribute)
+                     and string-length(normalize-space($xml-lang-attribute)) gt 0"
+               >Rule 11-30: An occurrence of xs:documentation within the schema MUST be in the scope of an occurrence of attribute xml:lang that has a value that is not empty.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-31"><sch:title>Standard opening phrase for augmentation point element data definition</sch:title>
+ <sch:rule context="xs:element[ends-with(@name, 'AugmentationPoint')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(starts-with(lower-case(normalize-space(.)), 'an augmentation point '))"
+     >The data definition for an augmentation point element SHOULD begin with standard opening phrase "An augmentation point...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-32"><sch:title>Standard opening phrase for augmentation element data definition</sch:title>
+ <sch:rule context="xs:element[ends-with(@name, 'Augmentation')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="every $phrase
+             in ('supplements ', 'additional information about ')
+             satisfies not(starts-with(lower-case(normalize-space(.)), $phrase))"
+     >The data definition for an augmentation element SHOULD begin with the standard opening phrase "Supplements..." or "Additional information about...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-33"><sch:title>Standard opening phrase for metadata element data definition</sch:title>
+ <sch:rule context="xs:element[ends-with(@name, 'Metadata')
+                               and not(xs:boolean(@abstract) eq true())]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '(metadata about|information that further qualifies)'))"
+     >The data definition for a metadata element SHOULD begin with the standard opening phrase "Metadata about..." or "Information that further qualifies...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-34"><sch:title>Standard opening phrase for association element data definition</sch:title>
+ <sch:rule context="xs:element[ends-with(@name, 'Association')
+                               and not(xs:boolean(@abstract) eq true())]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? (relationship|association)'))"
+     >The data definition for an association element that is not abstract SHOULD begin with the standard opening phrase "An (optional adjectives) (relationship|association)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-35"><sch:title>Standard opening phrase for abstract element data definition</sch:title>
+ <sch:rule context="xs:element[xs:boolean(@abstract) = true()
+                      and not(ends-with(@name, 'AugmentationPoint'))]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(starts-with(lower-case(normalize-space(.)), 'a data concept'))"
+     >The data definition for an abstract element SHOULD begin with the standard opening phrase "A data concept...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-36"><sch:title>Standard opening phrase for date element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Date') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? (date|month|year)'))"
+     >The data definition for an element or attribute with a date representation term SHOULD begin with the standard opening phrase "(A|An) (optional adjectives) (date|month|year)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-37"><sch:title>Standard opening phrase for quantity element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Quantity') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? (count|number)'))"
+     >The data definition for an element or attribute with a quantity representation term SHOULD begin with the standard opening phrase "An (optional adjectives) (count|number)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-38"><sch:title>Standard opening phrase for picture element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Picture') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? (image|picture|photograph)'))"
+     >The data definition for an element or attribute with a picture representation term SHOULD begin with the standard opening phrase "An (optional adjectives) (image|picture|photograph)".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-39"><sch:title>Standard opening phrase for indicator element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Indicator') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^true if .*; false (otherwise|if)'))"
+     >The data definition for an element or attribute with an indicator representation term SHOULD begin with the standard opening phrase "True if ...; false (otherwise|if)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-40"><sch:title>Standard opening phrase for identification element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Identification') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? identification'))"
+     >The data definition for an element or attribute with an identification representation term SHOULD begin with the standard opening phrase "(A|An) (optional adjectives) identification...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-41"><sch:title>Standard opening phrase for name element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Name') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^(a|an)( .*)? name'))"
+     >The data definition for an element or attribute with a name representation term SHOULD begin with the standard opening phrase "(A|An) (optional adjectives) name...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-42"><sch:title>Standard opening phrase for element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and @name
+                      and not(ends-with(@name, 'Indicator'))
+                      and not(ends-with(@name, 'Augmentation'))
+                      and not(ends-with(@name, 'Metadata'))
+                      and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an? '))"
+     >The data definition for an element or attribute declaration SHOULD begin with the standard opening phrase "(A|An)".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-43"><sch:title>Standard opening phrase for association type data definition</sch:title>
+ <sch:rule context="xs:complexType[ends-with(@name, 'AssociationType')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^a data type for (a relationship|an association)'))"
+     >The data definition for an association type SHOULD begin with the standard opening phrase "A data type for (a relationship|an association)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-44"><sch:title>Standard opening phrase for augmentation type data definition</sch:title>
+ <sch:rule context="xs:complexType[ends-with(@name, 'AugmentationType')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)),
+                         '^a data type (that supplements|for additional information about)'))"
+     >The data definition for an augmentation type SHOULD begin with the standard opening phrase "A data type (that supplements|for additional information about)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-45"><sch:title>Standard opening phrase for metadata type data definition</sch:title>
+ <sch:rule context="xs:complexType[ends-with(@name, 'MetadataType')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)),
+                         '^a data type for (metadata about|information that further qualifies)'))"
+     >The data definition for a metadata type SHOULD begin with the standard opening phrase "A data type for (metadata about|information that further qualifies)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-46"><sch:title>Standard opening phrase for complex type data definition</sch:title>
+ <sch:rule context="xs:complexType/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^a data type'))"
+     >The data definition for a complex type SHOULD begin with the standard opening phrase "A data type...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-47"><sch:title>Standard opening phrase for simple type data definition</sch:title>
+ <sch:rule context="xs:simpleType/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^a data type'))"
+     >The data definition for a simple type SHOULD begin with a standard opening phrase "A data type...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-52"><sch:title>Structures imported as conformant</sch:title>
+<sch:rule context="xs:import[exists(@namespace)
+                           and xs:anyURI(@namespace) = xs:anyURI(
+                   'https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/')]">
+<sch:assert test="empty(@appinfo:externalImportIndicator)"
+  >Rule 11-52: An import of the structures namespace MUST NOT be labeled as an external import.</sch:assert>
+</sch:rule>
+</sch:pattern><sch:pattern id="rule_11-53"><sch:title>XML namespace imported as conformant</sch:title>
+ <sch:rule context="xs:import[exists(@namespace)
+                              and xs:anyURI(@namespace) = xs:anyURI('http://www.w3.org/XML/1998/namespace')]">
+   <sch:assert test="empty(@appinfo:externalImportIndicator)"
+     >Rule 11-53: An import of the XML namespace MUST NOT be labeled as an external import.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-55"><sch:title>Consistently marked namespace imports</sch:title>
+ <sch:rule context="xs:import">
+   <sch:let name="namespace" value="@namespace"/>
+   <sch:let name="is-conformant" value="empty(@appinfo:externalImportIndicator)"/>
+   <sch:let name="first" value="exactly-one(parent::xs:schema/xs:import[@namespace = $namespace][1])"/>
+   <sch:assert test=". is $first
+                     or $is-conformant = empty($first/@appinfo:externalImportIndicator)"
+           >Rule 11-55: All xs:import elements that have the same namespace MUST have the same conformance marking via appinfo:externalImportIndicator.</sch:assert>
+ </sch:rule>
+</sch:pattern></sch:schema>

--- a/ndr-ct-sub.sch
+++ b/ndr-ct-sub.sch
@@ -1,0 +1,1007 @@
+<?xml version="1.0" encoding="US-ASCII" standalone="yes"?>
+<sch:schema
+  xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform" queryBinding="xslt2">
+<sch:title>Rules for subset XML Schema documents</sch:title>
+<xsl:include href="ndr-functions.xsl"/>
+<sch:ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
+<sch:ns prefix="xsl" uri="http://www.w3.org/1999/XSL/Transform"/>
+<sch:ns prefix="nf" uri="https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#NDRFunctions"/>
+<sch:ns prefix="ct" uri="https://docs.oasis-open.org/niemopen/ns/specification/conformanceTargets/3.0/"/>
+<sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+<sch:ns prefix="appinfo" uri="https://docs.oasis-open.org/niemopen/ns/model/appinfo/6.0/"/>
+<sch:ns prefix="structures" uri="https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/"/>
+<sch:pattern id="rule_4-6"><sch:title>Document element has attribute ct:conformanceTargets</sch:title>
+ <sch:rule context="*[. is nf:get-document-element(.)
+                      or exists(@ct:conformanceTargets)]">
+   <sch:assert test="(. is nf:get-document-element(.)) = exists(@ct:conformanceTargets)"
+     >Rule 4-6: The [document element] of the XML document, and only the [document element], MUST own an attribute {https://docs.oasis-open.org/niemopen/ns/specification/conformanceTargets/3.0/}conformanceTargets.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_4-9"><sch:title>Schema claims subset conformance target</sch:title>
+ <sch:rule context="*[. is nf:get-document-element(.)]">
+   <sch:assert test="nf:has-effective-conformance-target-identifier(., xs:anyURI(https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#SubsetSchemaDocument'))"
+     >Rule 4-9: The document MUST have an effective conformance target identifier of https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#SubsetSchemaDocument.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-1"><sch:title>No base type in the XML namespace</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="namespace-uri-from-QName(resolve-QName(@base, .)) != xs:anyURI('http://www.w3.org/XML/1998/namespace')"
+     >Rule 9-1: A schema component must not have a base type definition with a {target namespace} that is the XML namespace.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-2"><sch:title>No base type of xs:ID</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:ID')"
+     >Rule 9-2: A schema component MUST NOT have an attribute {}base with a value of xs:ID.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-3"><sch:title>No base type of xs:IDREF</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:IDREF')"
+     >Rule 9-3: A schema component MUST NOT have an attribute {}base with a value of xs:IDREF.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-4"><sch:title>No base type of xs:IDREFS</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:IDREFS')"
+     >Rule 9-4: A schema component MUST NOT have an attribute {}base with a value of xs:IDREFS.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-5"><sch:title>No base type of xs:anyType</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:anyType')"
+     >Rule 9-5: A schema component MUST NOT have an attribute {}base with a value of xs:anyType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-6"><sch:title>No base type of xs:anySimpleType</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:anySimpleType')"
+     >Rule 9-6: A schema component MUST NOT have an attribute {}base with a value of xs:anySimpleType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-7"><sch:title>No base type of xs:NOTATION</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:NOTATION')"
+     >Rule 9-7: A schema component MUST NOT have an attribute {}base with a value of xs:NOTATION.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-8"><sch:title>No base type of xs:ENTITY</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:ENTITY')"
+     >Rule 9-8: A schema component MUST NOT have an attribute {}base with a value of xs:ENTITY.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-9"><sch:title>No base type of xs:ENTITIES</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="resolve-QName(@base, .) != xs:QName('xs:ENTITIES')"
+     >Rule 9-9: A schema component MUST NOT have an attribute {}base with a value of xs:ENTITIES.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-10"><sch:title>Simple type definition is top-level</sch:title>
+ <sch:rule context="xs:simpleType">
+   <sch:assert test="exists(parent::xs:schema)"
+     >Rule 9-10: A simple type definition MUST be top-level.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-12"><sch:title>Simple type has data definition</sch:title>
+ <sch:rule context="xs:simpleType">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-12: A simple type MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-14"><sch:title>Enumeration has data definition</sch:title>
+ <sch:rule context="xs:enumeration">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-14: An enumeration facet MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-15"><sch:title>No list item type of xs:ID</sch:title>
+ <sch:rule context="xs:*[exists(@itemType)]">
+   <sch:assert test="resolve-QName(@itemType, .) != xs:QName('xs:ID')"
+     >Rule 9-15: A schema component MUST NOT have an attribute {}itemType with a value of xs:ID.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-16"><sch:title>No list item type of xs:IDREF</sch:title>
+ <sch:rule context="xs:*[exists(@itemType)]">
+   <sch:assert test="resolve-QName(@itemType, .) != xs:QName('xs:IDREF')"
+     >Rule 9-16: A schema component MUST NOT have an attribute {}itemType with a value of xs:IDREF.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-17"><sch:title>No list item type of xs:anySimpleType</sch:title>
+ <sch:rule context="xs:*[exists(@itemType)]">
+   <sch:assert test="resolve-QName(@itemType, .) != xs:QName('xs:anySimpleType')"
+     >Rule 9-17: A schema component MUST NOT have an attribute {}itemType with a value of xs:anySimpleType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-18"><sch:title>No list item type of xs:ENTITY</sch:title>
+ <sch:rule context="xs:*[exists(@itemType)]">
+   <sch:assert test="resolve-QName(@itemType, .) != xs:QName('xs:ENTITY')"
+     >Rule 9-18: A schema component MUST NOT have an attribute {}itemType with a value of xs:ENTITY.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-19"><sch:title>No union member types of xs:ID</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:ID')"
+     >Rule 9-19: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:ID.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-20"><sch:title>No union member types of xs:IDREF</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:IDREF')"
+     >Rule 9-20: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:IDREF.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-21"><sch:title>No union member types of xs:IDREFS</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:IDREFS')"
+     >Rule 9-21: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:IDREFS.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-22"><sch:title>No union member types of xs:anySimpleType</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:anySimpleType')"
+     >Rule 9-22: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:anySimpleType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-23"><sch:title>No union member types of xs:ENTITY</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:ENTITY')"
+     >Rule 9-23: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:ENTITY.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-24"><sch:title>No union member types of xs:ENTITIES</sch:title>
+ <sch:rule context="xs:*[exists(@memberTypes)]">
+   <sch:assert test="every $type-qname
+                     in tokenize(normalize-space(@memberTypes), ' ')
+                     satisfies resolve-QName($type-qname, .) != xs:QName('xs:ENTITIES')"
+     >Rule 9-24: A schema component MUST NOT have an attribute {}memberTypes that includes a value of xs:ENTITIES.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-25"><sch:title>Complex type definition is top-level</sch:title>
+ <sch:rule context="xs:complexType">
+   <sch:assert test="exists(parent::xs:schema)"
+     >Rule 9-25: A complex type definition MUST be top-level.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-26"><sch:title>Complex type has data definition</sch:title>
+ <sch:rule context="xs:complexType">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-26: A complex type MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-27"><sch:title>No mixed content on complex type</sch:title>
+ <sch:rule context="xs:complexType[exists(@mixed)]">
+   <sch:assert test="xs:boolean(@mixed) = false()"
+     >Rule 9-27: A complex type definition MUST NOT have mixed content.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-28"><sch:title>No mixed content on complex content</sch:title>
+ <sch:rule context="xs:complexContent[exists(@mixed)]">
+   <sch:assert test="xs:boolean(@mixed) = false()"
+     >Rule 9-28: A complex type definition with complex content MUST NOT have mixed content.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-29"><sch:title>Complex type content is explicitly simple or complex</sch:title>
+ <sch:rule context="xs:complexType">
+   <sch:assert test="exists(xs:simpleContent) or exists(xs:complexContent)"
+     >Rule 9-29: An element xs:complexType MUST have a child element xs:simpleContent or xs:complexContent.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-31"><sch:title>Base type of complex type with complex content must have complex content</sch:title>
+ <sch:rule context="xs:complexType/xs:complexContent/xs:*[
+                      (self::xs:extension or self::xs:restriction)
+                      and (some $base-qname in resolve-QName(@base, .) satisfies
+                             namespace-uri-from-QName($base-qname) = nf:get-target-namespace(.))]">
+   <sch:assert test="some $base-type in nf:resolve-type(., resolve-QName(@base, .)) satisfies
+                       empty($base-type/self::xs:complexType/xs:simpleContent)">Rule 9-31: 
+    The base type of complex type that has complex content MUST be a complex type with complex content.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-36"><sch:title>Element declaration is top-level</sch:title>
+ <sch:rule context="xs:element[exists(@name)]">
+   <sch:assert test="exists(parent::xs:schema)">Rule 9-36: 
+     An element declaration MUST be top-level.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-37"><sch:title>Element declaration has data definition</sch:title>
+ <sch:rule context="xs:element[exists(@name)]">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0">Rule 9-37: 
+     An element declaration MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-38"><sch:title>Untyped element is abstract</sch:title>
+ <sch:rule context="xs:schema/xs:element[empty(@type)]">
+   <sch:assert test="exists(@abstract)
+                     and xs:boolean(@abstract) = true()">Rule 9-38: 
+     A top-level element declaration that does not set the {type definition} property via the attribute "type" MUST have the {abstract} property with a value of "true".</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-39"><sch:title>Element of type xs:anySimpleType is abstract</sch:title>
+ <sch:rule context="xs:element[exists(@type)
+                               and resolve-QName(@type, .) = xs:QName('xs:anySimpleType')]">
+   <sch:assert test="exists(@abstract)
+                     and xs:boolean(@abstract) = true()">Rule 9-39: 
+               An element declaration that has a type xs:anySimpleType MUST have the {abstract} property with a value of "true".</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-41"><sch:title>Element type not in the XML namespace</sch:title>
+ <sch:rule context="xs:element[exists(@type)]">
+   <sch:assert test="namespace-uri-from-QName(resolve-QName(@type, .)) != 'http://www.w3.org/XML/1998/namespace'">Rule 9-41: 
+     An element type MUST NOT have a namespace name that is in the XML namespace.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-42"><sch:title>Element type is not simple type</sch:title>
+ <sch:rule context="xs:element[@type]">
+   <sch:assert test="every $type-qname in resolve-QName(@type, .),
+                           $type-ns in namespace-uri-from-QName($type-qname),
+                           $type-local-name in local-name-from-QName($type-qname) satisfies (
+                       $type-qname = xs:QName('xs:anySimpleType')
+                       or (($type-ns = nf:get-target-namespace(.)
+                            or exists(nf:get-document-element(.)/xs:import[
+                                        xs:anyURI(@namespace) = $type-ns
+                                        and empty(@appinfo:externalImportIndicator)]))
+                           and not(ends-with($type-local-name, 'SimpleType'))))">Rule 9-42: 
+     An element type that is not xs:anySimpleType MUST NOT be a simple type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-48"><sch:title>Attribute declaration is top-level</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:assert test="exists(parent::xs:schema)"
+     >Rule 9-48: An attribute declaration MUST be top-level.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-49"><sch:title>Attribute declaration has data definition</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-49: An attribute declaration MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-50"><sch:title>Attribute declaration has type</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:assert test="exists(@type)"
+     >Rule 9-50: A top-level attribute declaration MUST have a type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-51"><sch:title>No attribute type of xs:ID</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:ID')"
+     >Rule 9-51: A schema component MUST NOT have an attribute {}type with a value of xs:ID.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-52"><sch:title>No attribute type of xs:IDREF</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:IDREF')"
+     >Rule 9-52: A schema component MUST NOT have an attribute {}type with a value of xs:IDREF.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-53"><sch:title>No attribute type of xs:IDREFS</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:IDREFS')"
+     >Rule 9-53: A schema component MUST NOT have an attribute {}type with a value of xs:IDREFS.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-54"><sch:title>No attribute type of xs:ENTITY</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:ENTITY')"
+     >Rule 9-54: A schema component MUST NOT have an attribute {}type with a value of xs:ENTITY.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-55"><sch:title>No attribute type of xs:ENTITIES</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:ENTITIES')"
+     >Rule 9-55: A schema component MUST NOT have an attribute {}type with a value of xs:ENTITIES.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-56"><sch:title>No attribute type of xs:anySimpleType</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:assert test="resolve-QName(@type, .) != xs:QName('xs:anySimpleType')"
+     >Rule 9-56: A schema component MUST NOT have an attribute {}type with a value of xs:anySimpleType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-59"><sch:title>No use of element xs:notation</sch:title>
+ <sch:rule context="xs:notation">
+   <sch:assert test="false()"
+     >Rule 9-59: The schema MUST NOT contain the element xs:notation.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-61"><sch:title>No xs:all</sch:title>
+ <sch:rule context="xs:all">
+   <sch:assert test="false()"
+     >Rule 9-61: The schema MUST NOT contain the element xs:all</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-63"><sch:title>xs:sequence must be child of xs:extension or xs:restriction</sch:title>
+ <sch:rule context="xs:sequence">
+   <sch:assert test="exists(parent::xs:extension) or exists(parent::xs:restriction)"
+     >Rule 9-63: An element xs:sequence MUST be a child of element xs:extension or xs:restriction.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-65"><sch:title>xs:choice must be child of xs:sequence</sch:title>
+ <sch:rule context="xs:choice">
+   <sch:assert test="exists(parent::xs:sequence)"
+     >Rule 9-65: An element xs:choice MUST be a child of element xs:sequence.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-66"><sch:title>Sequence has minimum cardinality 1</sch:title>
+ <sch:rule context="xs:sequence">
+   <sch:assert test="empty(@minOccurs) or xs:integer(@minOccurs) = 1"
+     >Rule 9-66: An element xs:sequence MUST either not have the attribute {}minOccurs, or that attribute MUST have a value of 1.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-67"><sch:title>Sequence has maximum cardinality 1</sch:title>
+ <sch:rule context="xs:sequence">
+   <sch:assert test="empty(@maxOccurs) or (@maxOccurs instance of xs:integer
+                                           and 1 = xs:integer(@maxOccurs))"
+     >Rule 9-67: An element xs:sequence MUST either not have the attribute {}maxOccurs, or that attribute MUST have a value of 1.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-68"><sch:title>Choice has minimum cardinality 1</sch:title>
+ <sch:rule context="xs:choice">
+   <sch:assert test="empty(@minOccurs) or 1 = xs:integer(@minOccurs)"
+     >Rule 9-68: An element xs:choice MUST either not have the attribute {}minOccurs, or that attribute MUST have a value of 1.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-69"><sch:title>Choice has maximum cardinality 1</sch:title>
+ <sch:rule context="xs:choice">
+   <sch:assert test="empty(@maxOccurs) or (@maxOccurs instance of xs:integer
+                                           and 1 = xs:integer(@maxOccurs))"
+     >Rule 9-69: An element xs:choice MUST either not have the attribute {}maxOccurs, or that attribute MUST have a value of 1.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-72"><sch:title>No use of xs:unique</sch:title>
+ <sch:rule context="xs:unique">
+   <sch:assert test="false()"
+     >Rule 9-72: The schema MUST NOT contain the element xs:unique.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-73"><sch:title>No use of xs:key</sch:title>
+ <sch:rule context="xs:key">
+   <sch:assert test="false()"
+     >Rule 9-73: The schema MUST NOT contain the element xs:key.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-74"><sch:title>No use of xs:keyref</sch:title>
+ <sch:rule context="xs:keyref">
+   <sch:assert test="false()"
+     >Rule 9-74: The schema MUST NOT contain the element xs:keyref.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-75"><sch:title>No use of xs:group</sch:title>
+ <sch:rule context="xs:group">
+   <sch:assert test="false()"
+     >Rule 9-75: The schema MUST NOT contain the element xs:group.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-76"><sch:title>No definition of attribute groups</sch:title>
+ <sch:rule context="xs:attributeGroup[@name]">
+   <sch:assert test="false()"
+     >Rule 9-76: The schema MUST NOT contain an attribute group definition schema component.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-77"><sch:title>Comment is not recommended</sch:title>
+ <sch:rule context="node()[comment()]">
+   <sch:report test="true()" role="warning"
+     >An XML Comment is not an XML Schema annotation component; an XML comment SHOULD NOT appear in the schema.</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-78"><sch:title>Documentation element has no element children</sch:title>
+ <sch:rule context="xs:documentation/node()">
+   <sch:assert test="self::text() or self::comment()"
+     >Rule 9-78: A child of element xs:documentation MUST be text or an XML comment.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-79"><sch:title>xs:appinfo children are comments, elements, or whitespace</sch:title>
+ <sch:rule context="xs:appinfo/node()">
+   <sch:assert test="self::comment()
+                     or self::element()
+                     or self::text()[string-length(normalize-space(.)) = 0]"
+     >Rule 9-79: A child of element xs:appinfo MUST be an element, a comment, or whitespace text.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-80"><sch:title>Appinfo child elements have namespaces</sch:title>
+ <sch:rule context="xs:appinfo/*">
+   <sch:assert test="namespace-uri() != xs:anyURI('')"
+     >Rule 9-80: An element that is a child of xs:appinfo MUST have a namespace name.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-81"><sch:title>Appinfo descendants are not XML Schema elements</sch:title>
+ <sch:rule context="xs:appinfo//xs:*">
+   <sch:assert test="false()"
+     >Rule 9-81: An element with a namespace name of xs: MUST NOT have an ancestor element xs:appinfo.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-82"><sch:title>Schema has data definition</sch:title>
+ <sch:rule context="xs:schema">
+   <sch:assert test="some $definition in (xs:annotation/xs:documentation)[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 9-82: An element xs:schema MUST have a data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-83"><sch:title>Schema document defines target namespace</sch:title>
+ <sch:rule context="xs:schema">
+   <sch:assert test="exists(@targetNamespace)"
+     >Rule 9-83: The schema MUST define a target namespace.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-85"><sch:title>Schema has version</sch:title>
+ <sch:rule context="xs:schema">
+   <sch:assert test="some $version in @version satisfies
+                     string-length(normalize-space(@version)) &gt; 0"
+       >Rule 9-85: An element xs:schema MUST have an attribute {}version that MUST NOT be empty.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-88"><sch:title>No use of xs:redefine</sch:title>
+ <sch:rule context="xs:redefine">
+   <sch:assert test="false()"
+     >Rule 9-88: The schema MUST NOT contain the element xs:redefine.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-89"><sch:title>No use of xs:include</sch:title>
+ <sch:rule context="xs:include">
+   <sch:assert test="false()"
+     >Rule 9-89: The schema MUST NOT contain the element xs:include.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-90"><sch:title>xs:import must have namespace</sch:title>
+ <sch:rule context="xs:import">
+   <sch:assert test="exists(@namespace)"
+     >Rule 9-90: An element xs:import MUST have an attribute {}namespace.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-92"><sch:title>Namespace referenced by attribute type is imported</sch:title>
+ <sch:rule context="xs:*[@type]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@type, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or $namespace = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace])"
+               >Rule 9-92: The namespace of a type referenced by @type MUST be the target namespace, the XML Schema namespace, or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-93"><sch:title>Namespace referenced by attribute base is imported</sch:title>
+ <sch:rule context="xs:*[@base]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@base, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or $namespace = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace])"
+               >Rule 9-93: The namespace of a type referenced by @base MUST be the target namespace, the XML Schema namespace, or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-94"><sch:title>Namespace referenced by attribute itemType is imported</sch:title>
+ <sch:rule context="xs:*[@itemType]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@itemType, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or $namespace = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace])"
+               >Rule 9-94: The namespace of a type referenced by @itemType MUST be the target namespace, the XML Schema namespace, or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-95"><sch:title>Namespaces referenced by attribute memberTypes is imported</sch:title>
+ <sch:rule context="xs:*[@memberTypes]">
+   <sch:assert test="every $type in tokenize(normalize-space(@memberTypes), ' '),
+                           $namespace in namespace-uri-from-QName(resolve-QName($type, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or $namespace = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace])"
+               >Rule 9-95: The namespace of a type referenced by @memberTypes MUST be the target namespace, the XML Schema namespace, or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-96"><sch:title>Namespace referenced by attribute ref is imported</sch:title>
+ <sch:rule context="xs:*[@ref]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies
+                       $namespace = nf:get-target-namespace(.)
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace]"
+               >Rule 9-96: The namespace of a component referenced by @ref MUST be the target namespace or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_9-97"><sch:title>Namespace referenced by attribute substitutionGroup is imported</sch:title>
+ <sch:rule context="xs:*[@substitutionGroup]">
+   <sch:assert test="every $namespace in namespace-uri-from-QName(resolve-QName(@substitutionGroup, .)) satisfies
+                       $namespace = nf:get-target-namespace(.)
+                       or nf:get-document-element(.)/xs:import[xs:anyURI(@namespace) = $namespace]"
+               >Rule 9-97: The namespace of a component referenced by @substitutionGroup MUST be the target namespace or be imported.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-2"><sch:title>Object type with complex content is derived from structures:ObjectType</sch:title>
+ <sch:rule context="xs:complexType[exists(xs:complexContent)
+                                   and not(ends-with(@name, 'AssociationType')
+                                       or ends-with(@name, 'MetadataType')
+                                       or ends-with(@name, 'AugmentationType'))]">
+   <sch:assert test="
+       every $derivation-method in (xs:complexContent/xs:extension, xs:complexContent/xs:restriction),
+             $base in $derivation-method/@base,
+             $base-qname in resolve-QName($base, $derivation-method),
+             $base-local-name in local-name-from-QName($base-qname) satisfies (
+         $base-qname = xs:QName('structures:ObjectType')
+         or not(ends-with($base-local-name, 'AssociationType')
+                or ends-with($base-local-name, 'AugmentationType')))"
+     >Rule 10-2: An object type with complex content MUST be derived from structures:ObjectType or from another object type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-7"><sch:title>Import of external namespace has data definition</sch:title>
+ <sch:rule context="xs:import[@appinfo:externalImportIndicator]">
+   <sch:assert test="some $definition in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($definition))) &gt; 0"
+     >Rule 10-7: An element xs:import that is annotated as importing an external schema document MUST be a documented component.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-9"><sch:title>Structure of external adapter type definition follows pattern</sch:title>
+ <sch:rule context="xs:complexType[@appinfo:externalAdapterTypeIndicator]">
+   <sch:assert test="xs:complexContent/xs:extension[
+                       resolve-QName(@base, .) = xs:QName('structures:ObjectType')
+                     ]/xs:sequence"
+     >Rule 10-9: An external adapter type definition MUST be a complex type definition with complex content that extends structures:ObjectType, and that uses xs:sequence as its top-level compositor.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-10"><sch:title>Element use from external adapter type defined by external schema documents</sch:title>
+ <sch:rule context="xs:element[@ref
+                               and exists(ancestor::xs:complexType[exists(@appinfo:externalAdapterTypeIndicator)])]">
+   <sch:assert test="some $ref-namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies
+                       nf:get-document-element(.)/xs:import[
+                         $ref-namespace = xs:anyURI(@namespace)
+                         and @appinfo:externalImportIndicator]"
+     >Rule 10-10: An element reference that appears within an external adapter type MUST have a target namespace that is imported as external.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-11"><sch:title>External adapter type not a base type</sch:title>
+ <sch:rule context="xs:*[(self::xs:extension or self::xs:restriction)
+                         and (some $base-qname in resolve-QName(@base, .),
+                                   $base-namespace in namespace-uri-from-QName($base-qname) satisfies
+                                nf:get-target-namespace(.) = $base-namespace)]">
+   <sch:assert test="nf:resolve-type(., resolve-QName(@base, .))[
+                       empty(@appinfo:externalAdapterTypeIndicator)]"
+      >Rule 10-11: An external adapter type definition MUST NOT be a base type definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-14"><sch:title>External attribute use has data definition</sch:title>
+ <sch:rule context="xs:attribute[some $ref-namespace in namespace-uri-from-QName(resolve-QName(@ref, .)),
+                                      $import in ancestor::xs:schema[1]/xs:import satisfies (
+                                   xs:anyURI($import/@namespace) = $ref-namespace
+                                   and exists(@appinfo:externalImportIndicator))]">
+   <sch:assert test="some $documentation in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($documentation))) &gt; 0"
+     >Rule 10-14: An external attribute use MUST be a documented component with a non-empty data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-16"><sch:title>External element use has data definition</sch:title>
+ <sch:rule context="xs:element[
+     some $ref-namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies
+       nf:get-document-element(.)/self::xs:schema//xs:import[
+         xs:anyURI(@namespace) = $ref-namespace
+         and @appinfo:externalImportIndicator]]">
+   <sch:assert test="some $documentation in xs:annotation/xs:documentation[1] satisfies
+                       string-length(normalize-space(string($documentation))) &gt; 0"
+     >Rule 10-16: An external attribute use MUST be a documented component with a non-empty data definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-17"><sch:title>Name of code type ends in "CodeType"</sch:title>
+ <sch:rule context="xs:complexType[exists(xs:simpleContent[
+                      exists(xs:*[local-name() = ('extension', 'restriction')
+                                  and (ends-with(@base, 'CodeSimpleType')
+                                  or ends-with(@base, 'CodeType'))])])]">
+   <sch:report role="warning"
+       test="not(ends-with(@name, 'CodeType'))"
+     >A complex type definition with a {base type definition} of a code type or code simple type SHOULD have a {name} that ends in 'CodeType'.</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-19"><sch:title>Element of code type has code representation term</sch:title>
+ <sch:rule context="xs:element[exists(@name) and exists(@type) and ends-with(@type, 'CodeType')]">
+   <sch:report role="warning"
+       test="not(ends-with(@name, 'Code'))"
+     >An element with a type that is a code type SHOULD have a name with representation term "Code"</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-20"><sch:title>Proxy type has designated structure</sch:title>
+ <sch:rule context="xs:complexType[some $name in @name,
+                                   $extension in xs:simpleContent/xs:extension,
+                                   $base-qname in resolve-QName($extension/@base, $extension) satisfies
+                                   $base-qname = QName('http://www.w3.org/2001/XMLSchema', $name)]">
+   <sch:assert test="xs:simpleContent[
+                       xs:extension[
+                         empty(xs:attribute)
+                         and count(xs:attributeGroup) = 1
+                         and xs:attributeGroup[
+                               resolve-QName(@ref, .) = xs:QName('structures:SimpleObjectAttributeGroup')]]]"
+     >Rule 10-20: A proxy type MUST have the designated structure. It MUST use xs:extension. It MUST NOT use xs:attribute. It MUST include exactly one xs:attributeGroup reference, which must be to structures:SimpleObjectAttributeGroup.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-21"><sch:title>Association type derived from structures:AssociationType</sch:title>
+ <sch:rule context="xs:complexType">
+   <sch:let name="is-association-type" value="exists(@name[ends-with(., 'AssociationType')])"/>
+   <sch:let name="has-association-base-type" value="
+     exists(xs:complexContent[
+       exists(xs:*[local-name() = ('extension', 'restriction')
+                   and exists(@base[ends-with(., 'AssociationType')])])])"/>
+   <sch:assert test="$is-association-type = $has-association-base-type"
+     >Rule 10-21: A type MUST have an association type name if and only if it is derived from an association type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-22"><sch:title>Association element type is an association type</sch:title>
+ <sch:rule context="xs:element[exists(@name)]">
+   <sch:assert test="exists(@type[ends-with(., 'AssociationType')])
+                     = exists(@name[ends-with(., 'Association')])"
+     >Rule 10-22: An element MUST have a name that ends in 'Association' if and only if it has a type that is an association type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-24"><sch:title>Augmentable type has at most one augmentation point element</sch:title>
+ <sch:rule context="xs:complexType[
+                      @name[not(ends-with(., 'MetadataType'))
+                            and not(ends-with(., 'AugmentationType'))]
+                      and empty(@appinfo:externalAdapterTypeIndicator)
+                      and xs:complexContent]">
+   <sch:let name="augmentation-point-qname"
+            value="QName(string(nf:get-target-namespace(.)),
+                         replace(./@name, 'Type$', 'AugmentationPoint'))"/>
+   <sch:assert test="count(xs:complexContent/xs:extension/xs:sequence/xs:element[
+                             @ref[resolve-QName(., ..) = $augmentation-point-qname]]) le 1"
+     >Rule 10-24: An augmentable type MUST contain no more than one element use of its corresponding augmentation point element.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-25"><sch:title>Augmentation point element corresponds to its base type</sch:title>
+ <sch:rule context="xs:element[exists(@name[
+                                matches(., 'AugmentationPoint$')])]">
+   <sch:let name="element-name" value="@name"/>
+   <sch:assert test="exists(
+                       parent::xs:schema/xs:complexType[
+                         @name = replace($element-name, 'AugmentationPoint$', 'Type')
+                         and exists(@name[
+                                 not(ends-with(., 'MetadataType'))
+                                 and not(ends-with(., 'AugmentationType'))])
+                               and empty(@appinfo:externalAdapterTypeIndicator)
+                               and exists(child::xs:complexContent)])"
+     >Rule 10-25: A schema document containing an element declaration for an augmentation point element MUST also contain a type definition for its base type, a corresponding augmentable type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-26"><sch:title>An augmentation point element has no type</sch:title>
+ <sch:rule context="xs:element[exists(@name[
+                                matches(., 'AugmentationPoint$')])]">
+   <sch:assert test="empty(@type)"
+       >Rule 10-26: An augmentation point element MUST have no type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-27"><sch:title>An augmentation point element has no substitution group</sch:title>
+ <sch:rule context="xs:element[exists(@name[
+                                matches(., 'AugmentationPoint$')])]">
+   <sch:assert test="empty(@substitutionGroup)"
+       >Rule 10-27: An augmentation point element MUST have no substitution group.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-28"><sch:title>Augmentation point element is only referenced by its base type</sch:title>
+ <sch:rule context="xs:complexType//xs:element[exists(@ref[
+                      matches(local-name-from-QName(resolve-QName(., ..)), 'AugmentationPoint$')]) ]">
+   <sch:assert test="QName(string(nf:get-target-namespace(ancestor::xs:complexType[1])), ancestor::xs:complexType[1]/@name)
+                     = QName(string(namespace-uri-from-QName(resolve-QName(@ref, .))),
+                         replace(local-name-from-QName(resolve-QName(@ref, .)), 'AugmentationPoint$', 'Type'))"
+     >Rule 10-28: An augmentation point element MUST only be referenced by its base type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-31"><sch:title>Augmentation point element use must be last element in its base type</sch:title>
+ <sch:rule context="xs:complexType//xs:element[exists(@ref[
+                          matches(local-name-from-QName(resolve-QName(., ..)), 'AugmentationPoint$')]) ]">
+   <sch:assert test="empty(following-sibling::*)"
+      >Rule 10-31: An augmentation point element particle MUST be the last element occurrence in its content model.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-34"><sch:title>Schema component with name ending in "AugmentationType" is an augmentation type</sch:title>
+ <sch:rule context="xs:*[ends-with(@name, 'AugmentationType')]">
+   <sch:assert test="self::xs:complexType/xs:complexContent/xs:*[
+                       (self::xs:extension or self::xs:restriction)
+                       and ends-with(@base, 'AugmentationType')]"
+      >Rule 10-34: An augmentation type definition schema component with {name} ending in 'AugmentationType' MUST be an augmentation type definition that is a complex type definition with complex content that extends or restricts an augmentation type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-35"><sch:title>Type derived from structures:AugmentationType is an augmentation type</sch:title>
+ <sch:rule context="xs:*[(self::xs:restriction or self::xs:extension)
+                         and ends-with(@base, 'AugmentationType')]">
+   <sch:assert test="ancestor::xs:complexType[ends-with(@name, 'AugmentationType')]"
+               >Rule 10-35: A type definition derived from an augmentation type MUST be an augmentation type definition</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-36"><sch:title>Augmentation element type is an augmentation type</sch:title>
+ <sch:rule context="xs:element[exists(@name)]">
+   <sch:assert test="exists(@type[ends-with(., 'AugmentationType')])
+                     = exists(@name[ends-with(., 'Augmentation')])"
+     >Rule 10-36: An element declaration MUST have a name that ends in "Augmentation" if and only if it has a type that is an augmentation type.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-42"><sch:title>Name of element that ends in "Representation" is abstract</sch:title>
+ <sch:rule context="xs:element[@name[ends-with(., 'Representation')]]">
+   <sch:report role="warning"
+       test="empty(@abstract) or xs:boolean(@abstract) = false()"
+     >An element declaration with a name that ends in 'Representation' SHOULD have the {abstract} property with a value of "true".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-45"><sch:title>Schema component name has xml:lang</sch:title>
+ <sch:rule context="xs:*[exists(@name)]">
+   <sch:let name="xml-lang-attribute" value="ancestor-or-self::*[exists(@xml:lang)][1]/@xml:lang"/>
+   <sch:assert test="exists($xml-lang-attribute)
+                     and string-length(normalize-space($xml-lang-attribute)) gt 0"
+               >Rule 10-45: The name of an XML Schema component defined by the schema MUST be in the scope of an occurrence of attribute xml:lang that has a value that is not empty.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-46"><sch:title>Schema component names have only specific characters</sch:title>
+ <sch:rule context="xs:*[exists(@name)]">
+   <sch:assert test="matches(@name, '^[A-Za-z0-9\-_\.]*$')"
+     >Rule 10-46: The name of an XML Schema component defined by the schema must be composed of only the characters uppercase 'A' through 'Z', lowercase 'a' through 'z', numbers '0' through '9', underscore, hyphen, and period.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-49"><sch:title>Attribute name begins with lower case letter</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:assert test="matches(@name, '^[a-z]')"
+     >Rule 10-49: Within the schema, any attribute declaration MUST have a name that begins with a lowercase letter
+     ('a'-'z').</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-50"><sch:title>Name of schema component other than attribute and proxy type begins with upper case letter</sch:title>
+ <sch:rule context="xs:attribute">
+   <sch:report test="false()" role="warning">This rule does not apply to an attribute.</sch:report>
+ </sch:rule>
+ <sch:rule context="xs:complexType[some $name in @name,
+                                   $extension in xs:simpleContent/xs:extension,
+                                   $base-qname in resolve-QName($extension/@base, $extension) satisfies
+                                   $base-qname = QName('http://www.w3.org/2001/XMLSchema', $name)]">
+   <sch:report test="false()" role="warning">This rule does not apply to a proxy types.</sch:report>
+ </sch:rule>
+ <sch:rule context="xs:*[exists(@name)]">
+   <sch:assert test="matches(@name, '^[A-Z]')"
+     >Rule 10-50: Within the schema, an XML Schema component that is not an attribute declaration or proxy type MUST have a name that begins with an upper-case letter ('A'-'Z').</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-69"><sch:title>Deprecated annotates schema component</sch:title>
+ <sch:rule context="*[exists(@appinfo:deprecated)]">
+   <sch:assert test="namespace-uri-from-QName(node-name(.)) = xs:anyURI('http://www.w3.org/2001/XMLSchema')"
+           >Rule 10-69: The attribute appinfo:deprecated MUST be owned by an element with a namespace name http://www.w3.org/2001/XMLSchema.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-70"><sch:title>External import indicator annotates import</sch:title>
+ <sch:rule context="*[exists(@appinfo:externalImportIndicator)]">
+   <sch:assert test="exists(self::xs:import)"
+       >Rule 10-70: The attribute {https://docs.oasis-open.org/niemopen/ns/model/appinfo/6.0/}externalImportIndicator MUST be owned by an element xs:import.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-71"><sch:title>External adapter type indicator annotates complex type</sch:title>
+ <sch:rule context="*[exists(@appinfo:externalAdapterTypeIndicator)]">
+   <sch:assert test="exists(self::xs:complexType)"
+           >Rule 10-71: The attribute appinfo:externalAdapterTypeIndicator MUST be owned by an element xs:complexType.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-76"><sch:title>appinfo:LocalTerm annotates schema</sch:title>
+ <sch:rule context="appinfo:LocalTerm">
+   <sch:assert test="parent::xs:appinfo[parent::xs:annotation[parent::xs:schema]]"
+     >Rule 10-76: The element appinfo:LocalTerm MUST be application information on an element xs:schema.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_10-77"><sch:title>appinfo:LocalTerm has literal or definition</sch:title>
+ <sch:rule context="appinfo:LocalTerm">
+   <sch:assert test="exists(@literal) or exists(@definition)"
+           >Rule 10-77: The element {https://docs.oasis-open.org/niemopen/ns/model/appinfo/6.0/}LocalTerm MUST have a literal or definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-1"><sch:title>Name of type ends in "Type"</sch:title>
+ <sch:rule context="xs:complexType[some $name in @name,
+                                   $extension in xs:simpleContent/xs:extension,
+                                   $base-qname in resolve-QName($extension/@base, $extension) satisfies
+                                   $base-qname = QName('http://www.w3.org/2001/XMLSchema', $name)]">
+   <sch:report test="false()" role="warning">The name of a proxy type does not end in "Type".</sch:report>
+ </sch:rule>
+ <sch:rule context="xs:*[(self::xs:simpleType or self::xs:complexType) and exists(@name)]">
+   <sch:assert test="ends-with(@name, 'Type')"
+     >Rule 11-1: A type definition schema component that does not define a proxy type MUST have a name that ends in "Type".</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-2"><sch:title>Only types have name ending in "Type" or "SimpleType"</sch:title>
+ <sch:rule context="xs:*[exists(@name) and ends-with(@name, 'SimpleType')]">
+   <sch:assert test="local-name() = 'simpleType'"
+               >Rule 11-2: A schema component with a name that ends in 'SimpleType' MUST be a simple type definition.</sch:assert>
+ </sch:rule>
+ <sch:rule context="xs:*[exists(@name) and ends-with(@name, 'Type')]">
+   <sch:assert test="local-name() = 'complexType'"
+               >A schema component with a name that ends in 'Type' and does not end in 'SimpleType' MUST be a complex type definition.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-3"><sch:title>Base type definition defined by conformant schema</sch:title>
+ <sch:rule context="xs:*[exists(@base)]">
+   <sch:assert test="some $base-namespace in namespace-uri-from-QName(resolve-QName(@base, .)) satisfies (
+                       $base-namespace = (nf:get-target-namespace(.), xs:anyURI('http://www.w3.org/2001/XMLSchema'))
+                       or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                                                  and $base-namespace = xs:anyURI(@namespace)
+                                                                  and empty(@appinfo:externalImportIndicator)]))"
+     >Rule 11-3: The {base type definition} of a type definition MUST have the target namespace or the XML Schema namespace or a namespace that is imported as conformant.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-4"><sch:title>Name of simple type ends in "SimpleType"</sch:title>
+ <sch:rule context="xs:simpleType[@name]">
+   <sch:assert test="ends-with(@name, 'SimpleType')"
+     >Rule 11-4: A simple type definition schema component MUST have a name that ends in "SimpleType".</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-6"><sch:title>List item type defined by conformant schemas</sch:title>
+ <sch:rule context="xs:list[exists(@itemType)]">
+   <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@itemType, .))"/>
+   <sch:assert test="$namespace = (nf:get-target-namespace(.), xs:anyURI('http://www.w3.org/2001/XMLSchema'))
+                     or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                   and $namespace = xs:anyURI(@namespace)
+                                   and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-6: The item type of a list simple type definition MUST have a target namespace equal to the target namespace of the XML Schema document within which it is defined, or a namespace that is imported as conformant by the schema document within which it is defined.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-7"><sch:title>Union member types defined by conformant schemas</sch:title>
+ <sch:rule context="xs:union[exists(@memberTypes)]">
+   <sch:assert test="every $qname in tokenize(normalize-space(@memberTypes), ' '),
+                           $namespace in namespace-uri-from-QName(resolve-QName($qname, .))
+                     satisfies ($namespace = nf:get-target-namespace(.)
+                                or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                          and $namespace = xs:anyURI(@namespace)
+                                          and empty(@appinfo:externalImportIndicator)]))"
+               >Rule 11-7: Every member type of a union simple type definition MUST have a target namespace that is equal to either the target namespace of the XML Schema document within which it is defined or a namespace that is imported as conformant by the schema document within which it is defined.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-8"><sch:title>Name of a code simple type ends in "CodeSimpleType"</sch:title>
+ <sch:rule context="xs:simpleType[exists(@name)
+     and (xs:restriction/xs:enumeration
+          or xs:restriction[ends-with(local-name-from-QName(resolve-QName(@base, .)), 'CodeSimpleType')])]">
+   <sch:report test="not(ends-with(@name, 'CodeSimpleType'))" role="warning"
+     >A simple type definition schema component that has an enumeration facet or that is derived from a code simple type SHOULD have a name that ends in "CodeSimpleType".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-10"><sch:title>Attribute of code simple type has code representation term</sch:title>
+ <sch:rule context="xs:attribute[exists(@name) and exists(@type) and ends-with(@type, 'CodeSimpleType')]">
+   <sch:report test="not(ends-with(@name, 'Code'))" role="warning"
+     >An attribute with a type that is a code simple type SHOULD have a name with representation term "Code"</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-11"><sch:title>Complex type with simple content has structures:SimpleObjectAttributeGroup</sch:title>
+ <sch:rule context="xs:simpleContent/xs:extension[
+     some $base-qname in resolve-QName(@base, .) satisfies
+       namespace-uri-from-QName($base-qname) = xs:anyURI('http://www.w3.org/2001/XMLSchema')
+       or ends-with(local-name-from-QName($base-qname), 'SimpleType')]">
+   <sch:assert test="xs:attributeGroup[
+                       resolve-QName(@ref, .) = xs:QName('structures:SimpleObjectAttributeGroup')]"
+     >Rule 11-11: A complex type definition with simple content schema component with a derivation method of extension that has a base type definition that is a simple type MUST incorporate the attribute group {https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/}SimpleObjectAttributeGroup.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-12"><sch:title>Element type does not have a simple type name</sch:title>
+ <sch:rule context="xs:element[exists(@type)]">
+   <sch:assert test="not(ends-with(@type, 'SimpleType'))"
+               >Rule 11-12: The {type definition} of an element declaration MUST NOT have a {name} that ends in 'SimpleType'.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-13"><sch:title>Element type is from conformant namespace</sch:title>
+ <sch:rule context="xs:element[exists(@type)]">
+   <sch:assert test="for $type-qname in resolve-QName(@type, .),
+                         $type-namespace in namespace-uri-from-QName($type-qname) return
+                       $type-namespace = nf:get-target-namespace(.)
+                       or exists(nf:get-document-element(.)/xs:import[
+                                   xs:anyURI(@namespace) = $type-namespace
+                                   and empty(@appinfo:externalImportIndicator)])"
+               >Rule 11-13: The {type definition} of an element declaration MUST have a {target namespace} that is the target namespace, or one that is imported as conformant.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-14"><sch:title>Name of element that ends in "Abstract" is abstract</sch:title>
+ <sch:rule context="xs:element[@name]">
+   <sch:report role="warning"
+       test="not(exists(@abstract[xs:boolean(.) = true()])
+                 eq (ends-with(@name, 'Abstract')
+                     or ends-with(@name, 'AugmentationPoint')
+                     or ends-with(@name, 'Representation')))"
+     >An element declaration SHOULD have a name that ends in 'Abstract', 'AugmentationPoint', or 'Representation' if and only if it has the {abstract} property with a value of "true".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-15"><sch:title>Name of element declaration with simple content has representation term</sch:title>
+ <sch:rule context="xs:element[@name and @type
+                               and (some $type-qname in resolve-QName(@type, .) satisfies (
+                                      nf:get-target-namespace(.) = namespace-uri-from-QName($type-qname)
+                                      and nf:resolve-type(., $type-qname)/xs:simpleContent))]">
+   <sch:report role="warning"
+       test="every $representation-term
+             in ('Amount', 'BinaryObject', 'Graphic', 'Picture', 'Sound', 'Video', 'Code', 'DateTime', 'Date', 'Time', 'Duration', 'ID', 'URI', 'Indicator', 'Measure', 'Numeric', 'Value', 'Rate', 'Percent', 'Quantity', 'Text', 'Name', 'List')
+             satisfies not(ends-with(@name, $representation-term))"
+     >The name of an element declaration that is of simple content SHOULD use a representation term.</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-17"><sch:title>Element substitution group defined by conformant schema</sch:title>
+ <sch:rule context="xs:element[exists(@substitutionGroup)]">
+   <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@substitutionGroup, .))"/>
+   <sch:assert test="$namespace = nf:get-target-namespace(.)
+                     or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                   and $namespace = xs:anyURI(@namespace)
+                                   and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-17: An element substitution group MUST have either the target namespace or a namespace that is imported as conformant.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-18"><sch:title>Attribute type defined by conformant schema</sch:title>
+ <sch:rule context="xs:attribute[exists(@type)]">
+   <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@type, .))"/>
+   <sch:assert test="$namespace = (nf:get-target-namespace(.), xs:anyURI('http://www.w3.org/2001/XMLSchema'))
+                     or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                   and $namespace = xs:anyURI(@namespace)
+                                   and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-18: The type of an attribute declaration MUST have the target namespace or the XML Schema namespace or a namespace that is imported as conformant.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-19"><sch:title>Attribute name uses representation term</sch:title>
+ <sch:rule context="xs:attribute[exists(@name)]">
+   <sch:report role="warning"
+       test="every $representation-term
+             in ('Amount', 'BinaryObject', 'Graphic', 'Picture', 'Sound', 'Video', 'Code', 'DateTime', 'Date', 'Time', 'Duration', 'ID', 'URI', 'Indicator', 'Measure', 'Numeric', 'Value', 'Rate', 'Percent', 'Quantity', 'Text', 'Name', 'List')
+             satisfies not(ends-with(@name, $representation-term))"
+     >An attribute name SHOULD end with a representation term.</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-21"><sch:title>Element reference defined by conformant schema</sch:title>
+ <sch:rule context="xs:element[exists(ancestor::xs:complexType[empty(@appinfo:externalAdapterTypeIndicator)]) and @ref]">
+   <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@ref, .))"/>
+   <sch:assert test="$namespace = nf:get-target-namespace(.)
+                     or exists(ancestor::xs:schema[1]/xs:import[exists(@namespace)
+                                   and $namespace = xs:anyURI(@namespace)
+                                   and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-21: An element reference MUST be to a component that has a namespace that is either the target namespace of the schema document in which it appears, or which is imported as conformant by that schema document.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-22"><sch:title>Referenced attribute defined by conformant schemas</sch:title>
+  <sch:rule context="xs:attribute[@ref]">
+     <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@ref, .))"/>
+     <sch:assert test="some $namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies (
+                       $namespace = nf:get-target-namespace(.)
+                       or ancestor::xs:schema[1]/xs:import[
+                            @namespace
+                            and $namespace = xs:anyURI(@namespace)
+                            and empty(@appinfo:externalImportIndicator)])"
+     >Rule 11-22: An attribute {}ref MUST have the target namespace or a namespace that is imported as conformant.     </sch:assert>
+  </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-23"><sch:title>Schema uses only known attribute groups</sch:title>
+  <sch:rule context="xs:attributeGroup[@ref]">
+    <sch:assert test="some $ref in resolve-QName(@ref, .) satisfies (
+                        $ref = xs:QName('structures:SimpleObjectAttributeGroup'))"
+      >Rule 11-23: An attribute group reference MUST be structures:SimpleObjectAttributeGroup</sch:assert>
+  </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-30"><sch:title>xs:documentation has xml:lang</sch:title>
+ <sch:rule context="xs:documentation">
+   <sch:let name="xml-lang-attribute" value="ancestor-or-self::*[exists(@xml:lang)][1]/@xml:lang"/>
+   <sch:assert test="exists($xml-lang-attribute)
+                     and string-length(normalize-space($xml-lang-attribute)) gt 0"
+               >Rule 11-30: An occurrence of xs:documentation within the schema MUST be in the scope of an occurrence of attribute xml:lang that has a value that is not empty.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-31"><sch:title>Standard opening phrase for augmentation point element data definition</sch:title>
+ <sch:rule context="xs:element[ends-with(@name, 'AugmentationPoint')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(starts-with(lower-case(normalize-space(.)), 'an augmentation point '))"
+     >The data definition for an augmentation point element SHOULD begin with standard opening phrase "An augmentation point...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-32"><sch:title>Standard opening phrase for augmentation element data definition</sch:title>
+ <sch:rule context="xs:element[ends-with(@name, 'Augmentation')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="every $phrase
+             in ('supplements ', 'additional information about ')
+             satisfies not(starts-with(lower-case(normalize-space(.)), $phrase))"
+     >The data definition for an augmentation element SHOULD begin with the standard opening phrase "Supplements..." or "Additional information about...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-33"><sch:title>Standard opening phrase for metadata element data definition</sch:title>
+ <sch:rule context="xs:element[ends-with(@name, 'Metadata')
+                               and not(xs:boolean(@abstract) eq true())]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '(metadata about|information that further qualifies)'))"
+     >The data definition for a metadata element SHOULD begin with the standard opening phrase "Metadata about..." or "Information that further qualifies...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-34"><sch:title>Standard opening phrase for association element data definition</sch:title>
+ <sch:rule context="xs:element[ends-with(@name, 'Association')
+                               and not(xs:boolean(@abstract) eq true())]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? (relationship|association)'))"
+     >The data definition for an association element that is not abstract SHOULD begin with the standard opening phrase "An (optional adjectives) (relationship|association)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-35"><sch:title>Standard opening phrase for abstract element data definition</sch:title>
+ <sch:rule context="xs:element[xs:boolean(@abstract) = true()
+                      and not(ends-with(@name, 'AugmentationPoint'))]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(starts-with(lower-case(normalize-space(.)), 'a data concept'))"
+     >The data definition for an abstract element SHOULD begin with the standard opening phrase "A data concept...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-36"><sch:title>Standard opening phrase for date element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Date') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? (date|month|year)'))"
+     >The data definition for an element or attribute with a date representation term SHOULD begin with the standard opening phrase "(A|An) (optional adjectives) (date|month|year)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-37"><sch:title>Standard opening phrase for quantity element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Quantity') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? (count|number)'))"
+     >The data definition for an element or attribute with a quantity representation term SHOULD begin with the standard opening phrase "An (optional adjectives) (count|number)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-38"><sch:title>Standard opening phrase for picture element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Picture') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? (image|picture|photograph)'))"
+     >The data definition for an element or attribute with a picture representation term SHOULD begin with the standard opening phrase "An (optional adjectives) (image|picture|photograph)".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-39"><sch:title>Standard opening phrase for indicator element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Indicator') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^true if .*; false (otherwise|if)'))"
+     >The data definition for an element or attribute with an indicator representation term SHOULD begin with the standard opening phrase "True if ...; false (otherwise|if)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-40"><sch:title>Standard opening phrase for identification element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Identification') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an?( .*)? identification'))"
+     >The data definition for an element or attribute with an identification representation term SHOULD begin with the standard opening phrase "(A|An) (optional adjectives) identification...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-41"><sch:title>Standard opening phrase for name element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and ends-with(@name, 'Name') and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^(a|an)( .*)? name'))"
+     >The data definition for an element or attribute with a name representation term SHOULD begin with the standard opening phrase "(A|An) (optional adjectives) name...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-42"><sch:title>Standard opening phrase for element or attribute data definition</sch:title>
+ <sch:rule context="*[(self::xs:element or self::xs:attribute)
+                      and @name
+                      and not(ends-with(@name, 'Indicator'))
+                      and not(ends-with(@name, 'Augmentation'))
+                      and not(ends-with(@name, 'Metadata'))
+                      and not(xs:boolean(@abstract) eq true())]
+                     /xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^an? '))"
+     >The data definition for an element or attribute declaration SHOULD begin with the standard opening phrase "(A|An)".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-43"><sch:title>Standard opening phrase for association type data definition</sch:title>
+ <sch:rule context="xs:complexType[ends-with(@name, 'AssociationType')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^a data type for (a relationship|an association)'))"
+     >The data definition for an association type SHOULD begin with the standard opening phrase "A data type for (a relationship|an association)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-44"><sch:title>Standard opening phrase for augmentation type data definition</sch:title>
+ <sch:rule context="xs:complexType[ends-with(@name, 'AugmentationType')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)),
+                         '^a data type (that supplements|for additional information about)'))"
+     >The data definition for an augmentation type SHOULD begin with the standard opening phrase "A data type (that supplements|for additional information about)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-45"><sch:title>Standard opening phrase for metadata type data definition</sch:title>
+ <sch:rule context="xs:complexType[ends-with(@name, 'MetadataType')]/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)),
+                         '^a data type for (metadata about|information that further qualifies)'))"
+     >The data definition for a metadata type SHOULD begin with the standard opening phrase "A data type for (metadata about|information that further qualifies)...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-46"><sch:title>Standard opening phrase for complex type data definition</sch:title>
+ <sch:rule context="xs:complexType/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^a data type'))"
+     >The data definition for a complex type SHOULD begin with the standard opening phrase "A data type...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-47"><sch:title>Standard opening phrase for simple type data definition</sch:title>
+ <sch:rule context="xs:simpleType/xs:annotation/xs:documentation[1]">
+   <sch:report role="warning"
+       test="not(matches(lower-case(normalize-space(.)), '^a data type'))"
+     >The data definition for a simple type SHOULD begin with a standard opening phrase "A data type...".</sch:report>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-52"><sch:title>Structures imported as conformant</sch:title>
+<sch:rule context="xs:import[exists(@namespace)
+                           and xs:anyURI(@namespace) = xs:anyURI(
+                   'https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/')]">
+<sch:assert test="empty(@appinfo:externalImportIndicator)"
+  >Rule 11-52: An import of the structures namespace MUST NOT be labeled as an external import.</sch:assert>
+</sch:rule>
+</sch:pattern><sch:pattern id="rule_11-53"><sch:title>XML namespace imported as conformant</sch:title>
+ <sch:rule context="xs:import[exists(@namespace)
+                              and xs:anyURI(@namespace) = xs:anyURI('http://www.w3.org/XML/1998/namespace')]">
+   <sch:assert test="empty(@appinfo:externalImportIndicator)"
+     >Rule 11-53: An import of the XML namespace MUST NOT be labeled as an external import.</sch:assert>
+ </sch:rule>
+</sch:pattern><sch:pattern id="rule_11-55"><sch:title>Consistently marked namespace imports</sch:title>
+ <sch:rule context="xs:import">
+   <sch:let name="namespace" value="@namespace"/>
+   <sch:let name="is-conformant" value="empty(@appinfo:externalImportIndicator)"/>
+   <sch:let name="first" value="exactly-one(parent::xs:schema/xs:import[@namespace = $namespace][1])"/>
+   <sch:assert test=". is $first
+                     or $is-conformant = empty($first/@appinfo:externalImportIndicator)"
+           >Rule 11-55: All xs:import elements that have the same namespace MUST have the same conformance marking via appinfo:externalImportIndicator.</sch:assert>
+ </sch:rule>
+</sch:pattern></sch:schema>

--- a/ndr-functions.xsl
+++ b/ndr-functions.xsl
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<stylesheet
+  version="2.0"
+  xmlns:catalog="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+  xmlns:ct="https://docs.oasis-open.org/niemopen/ns/specification/conformanceTargets/3.0/"
+  xmlns:impl="http://example.org/impl"
+  xmlns:nf="https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#NDRFunctions"
+  xmlns:saxon="http://saxon.sf.net/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1999/XSL/Transform">
+
+  <param name="xml-catalog" as="document-node()?"/>
+
+  <!-- Yields document element of the document containing element $context. -->
+  <function name="nf:get-document-element" as="element()">
+    <param name="context" as="element()"/>
+    <sequence select="root($context)/*"/>
+  </function>
+
+  <!-- Yields:
+       if element is within a schema
+         if there is a target namespace -> xs:anyURI( $namespace )
+         if there is no target namespace -> xs:anyURI('')
+       otherwise -> ()
+  -->
+  <function name="nf:get-target-namespace" as="xs:anyURI?">
+    <param name="element" as="element()"/>
+    <variable name="schema" as="element(xs:schema)?" select="root($element)/xs:schema"/>
+    <choose>
+      <when test="empty($schema)">
+        <message>
+          <value-of select="impl:get-location($element)"/>
+          <text>: nf:get-target-namespace(): document element is not xs:schema.</text>
+        </message>
+        <sequence select="()"/>
+      </when>
+      <otherwise>
+        <variable name="target-namespace-attr" as="attribute()?" select="$schema/@targetNamespace"/>
+        <sequence select="xs:anyURI(if (exists($target-namespace-attr))
+                                    then string($target-namespace-attr)
+                                    else '')"/>
+      </otherwise>
+    </choose>
+  </function>
+
+  <!-- Yields:
+       if the namespace is found in the catalog, and the first entry has /xs:schema  -> element(xs:schema)
+       otherwise -> ()
+  -->
+  <function name="nf:resolve-namespace" as="element(xs:schema)?">
+    <param name="context" as="element()"/>
+    <param name="namespace-uri" as="xs:anyURI"/>
+    <variable name="context-target-namespace-uri" as="xs:anyURI?" select="nf:get-target-namespace($context)"/>
+    <choose>
+      <!-- this SHOULD work for target namespace = xs:anyURI('') -->
+      <when test="exists($context-target-namespace-uri)                    
+                  and exactly-one($context-target-namespace-uri) = $namespace-uri">
+        <sequence select="root($context)/xs:schema"/>
+      </when>
+      <when test="empty($xml-catalog)">
+        <sequence select="error(xs:QName('impl:xml-catalog-not-set'), 'Error: $xml-catalog is not set')"/>
+      </when>
+      <otherwise>
+        <variable name="catalog-element" as="element(catalog:catalog)?" select="$xml-catalog/catalog:catalog"/>
+        <choose>
+          <when test="empty($catalog-element)">
+            <message>
+              <value-of select="impl:get-location($context)"/>
+              <text>: resolved catalog does not have document element catalog:catalog.</text>
+            </message>
+            <sequence select="()"/>
+          </when>
+          <otherwise>
+            <apply-templates select="$catalog-element" mode="impl:resolve-namespace">
+              <with-param name="namespace-uri" tunnel="yes" select="$namespace-uri"/>
+            </apply-templates>
+          </otherwise>
+        </choose>
+      </otherwise>
+    </choose>
+  </function>
+
+  <!-- Yields:
+       if the type resolves -> the first entry of xs:complexType or xs:simpleType
+       if not -> ()
+  -->
+  <function name="nf:resolve-type" as="element()?">
+    <param name="context" as="element()"/>
+    <param name="qname" as="xs:QName"/>
+    <variable name="namespace-uri" as="xs:anyURI" select="namespace-uri-from-QName($qname)"/>
+    <variable name="schema" as="element(xs:schema)?" select="nf:resolve-namespace($context, $namespace-uri)"/>
+    <choose>
+      <when test="empty($schema)">
+        <sequence select="()"/>
+      </when>
+      <otherwise>
+        <variable name="type" as="element()?"
+                  select="$schema/*[(self::xs:complexType or self::xs:simpleType)
+                                    and @name = local-name-from-QName($qname)][1]"/>
+        <choose>
+          <when test="empty($type)">
+            <message>
+              <value-of select="impl:get-location($context)"/>
+              <text>: type not found: </text>
+              <value-of select="impl:get-clark-name($qname)"/>
+              <text>.</text>
+            </message>
+            <sequence select="()"/>
+          </when>
+          <otherwise>
+            <sequence select="$type"/>
+          </otherwise>
+        </choose>
+      </otherwise>
+    </choose>
+  </function>
+
+  <!-- Yields:
+       if the element resolves -> the first xs:element
+       if not -> ()
+  -->
+  <function name="nf:resolve-element" as="element(xs:element)?">
+    <param name="context" as="element()"/>
+    <param name="qname" as="xs:QName"/>
+    <variable name="namespace-uri" as="xs:anyURI" select="namespace-uri-from-QName($qname)"/>
+    <variable name="schema" as="element(xs:schema)?" select="nf:resolve-namespace($context, $namespace-uri)"/>
+    <choose>
+      <when test="empty($schema)">
+        <!-- error message has already been dispatched by the catalog resolver -->
+        <sequence select="()"/>
+      </when>
+      <otherwise>
+        <variable name="element" as="element(xs:element)?"
+                  select="$schema/xs:element[@name = local-name-from-QName($qname)][1]"/>
+        <choose>
+          <when test="empty($element)">
+            <message>
+              <value-of select="impl:get-location($context)"/>
+              <text>: element not found.</text>
+            </message>
+            <sequence select="()"/>
+          </when>
+          <otherwise>
+            <sequence select="$element"/>
+          </otherwise>
+        </choose>
+      </otherwise>
+    </choose>
+  </function>
+
+  <function name="nf:has-effective-conformance-target-identifier" as="xs:boolean">
+    <param name="context" as="element()"/>
+    <param name="match" as="xs:anyURI"/>
+    <variable name="effective-conformance-targets-attribute" as="attribute()?"
+              select="(root($context)//*[exists(@ct:conformanceTargets)])[1]/@ct:conformanceTargets"/>
+    <sequence select="if (empty($effective-conformance-targets-attribute))
+                      then false()
+                      else some $effective-conformance-target-string
+                           in tokenize(normalize-space(string($effective-conformance-targets-attribute)), ' ')
+                           satisfies ($effective-conformance-target-string castable as xs:anyURI
+                                      and xs:anyURI($effective-conformance-target-string) = $match)"/>
+  </function>
+
+  <!-- ================================================================== -->
+  <!-- implementation details -->
+  <!-- ================================================================== -->
+
+  <function name="impl:get-clark-name" as="xs:string">
+    <param name="qname" as="xs:QName"/>
+    <value-of select="concat( '{', namespace-uri-from-QName($qname), '}', local-name-from-QName($qname) )"/>
+  </function>
+
+  <function name="impl:get-location" as="xs:string">
+    <param name="context" as="node()"/>
+    <value-of>
+      <value-of select="base-uri($context)"/>
+      <value-of use-when="function-available('saxon:line-number')"
+                select="concat(':', saxon:line-number($context))"/>
+    </value-of>
+  </function>
+
+  <!-- ================================================================== -->
+  <!-- mode = impl:resolve-namespace -->
+  <!-- XML Catalog processing code -->
+  <!-- ================================================================== -->
+
+  <template match="/catalog:catalog" mode="impl:resolve-namespace" as="element(xs:schema)?">
+    <param name="namespace-uri" as="xs:anyURI" tunnel="yes"/>
+    <variable name="next" as="element()?" select="(catalog:uri|catalog:nextCatalog)[1]"/>
+    <choose>
+      <when test="empty($next)">
+        <sequence select="()"/>
+      </when>
+      <otherwise>
+        <apply-templates select="$next" mode="#current"/>
+      </otherwise>
+    </choose>
+  </template>
+
+  <template match="catalog:uri" mode="impl:resolve-namespace" as="element(xs:schema)?">
+    <param name="namespace-uri" as="xs:anyURI" tunnel="yes"/>
+    <choose>
+      <when test="empty(@name)">
+        <message>
+          <value-of select="impl:get-location(.)"/>
+          <text>: catalog:uri has no @name.</text>
+        </message>
+        <sequence select="()"/>
+      </when>
+      <when test="xs:anyURI(@name) = $namespace-uri">
+        <variable name="uri" as="xs:anyURI?" select="resolve-uri(@uri, base-uri(.))"/>
+        <choose>
+          <when test="empty($uri)">
+            <message>
+              <value-of select="impl:get-location(.)"/>
+              <text>: catalog:uri has no @uri.</text>
+            </message>
+            <sequence select="()"/>
+          </when>
+          <when test="not(doc-available($uri))">
+            <message>
+              <value-of select="impl:get-location(.)"/>
+              <text>: catalog:uri @uri (</text>
+              <value-of select="$uri"/>
+              <text>) does not resolve.</text>
+            </message>
+            <sequence select="()"/>
+          </when>
+          <otherwise>
+            <variable name="doc" as="element(xs:schema)?" select="doc($uri)/xs:schema"/>
+            <choose>
+              <when test="empty($doc)">
+                <message>
+                  <value-of select="impl:get-location(.)"/>
+                  <text>: catalog:uri @uri does not resolve to schema</text>
+                </message>
+              </when>
+              <otherwise>
+                <sequence select="$doc"/>
+              </otherwise>
+            </choose>
+          </otherwise>
+        </choose>
+      </when>
+      <otherwise>
+        <apply-templates mode="#current" select="following-sibling::*[1]"/>
+      </otherwise>
+    </choose>
+  </template>
+
+  <template match="catalog:nextCatalog" mode="impl:resolve-namespace" as="element(xs:schema)?">
+    <param name="namespace-uri" as="xs:anyURI" tunnel="yes"/>
+    <variable name="catalog-uri" as="xs:anyURI" select="resolve-uri(@catalog, base-uri(.))"/>
+    <choose>
+      <when test="empty($catalog-uri)">
+        <message>
+          <value-of select="impl:get-location(.)"/>
+          <text>: catalog:nextCatalog does not have @catalog.</text>
+        </message>
+        <sequence select="()"/>
+      </when>
+      <when test="not(doc-available($catalog-uri))">
+        <message>
+          <value-of select="impl:get-location(.)"/>
+          <text>: catalog:nextCatalog/@catalog does not resolve.</text>
+        </message>
+        <sequence select="()"/>
+      </when>
+      <otherwise>
+        <variable name="catalog" as="element(catalog:catalog)?" select="doc($catalog-uri)/catalog:catalog"/>
+        <choose>
+          <when test="empty($catalog)">
+            <message>
+              <value-of select="impl:get-location(.)"/>
+              <text>: catalog:nextCatalog/@catalog resolves to something that is not a catalog.</text>
+            </message>
+            <sequence select="()"/>
+          </when>
+          <otherwise>
+            <apply-templates mode="#current" select="$catalog"/>
+          </otherwise>
+        </choose>
+      </otherwise>
+    </choose>
+  </template>
+
+</stylesheet>

--- a/niem-ndr.md
+++ b/niem-ndr.md
@@ -659,8 +659,11 @@ This section defines and describes conformance targets of this specification. Ea
 
 - [Section 4.1.1, _Reference schema document_](#reference-schema-document)
 - [Section 4.1.2, _Extension schema document_](#extension-schema-document)
-- [Section 4.1.3, _Schema document set_](#schema-document-set)
-- [Section 4.1.4, _Instance documents and elements_](#instance-documents-and-elements)
+- Section 4.1.3, Subset schema document
+- Section 4.1.4, Message schema document
+- [Section 4.1.5, _Source schema document set_](#schema-document-set)
+- Section 4.1.6, Message schema document set
+- [Section 4.1.7, _Instance documents and elements_](#instance-documents-and-elements)
 
 ### 4.1.1 Reference schema document
 
@@ -683,7 +686,7 @@ The rules for reference schema documents are more stringent than are the rules f
 
 Many reference schema documents are **optional and over-inclusive**. Data definitions in namespaces defined by reference schema documents are designed with parts that are intended to be omitted or refined as needed for a particular exchange. Many reference schema documents define more complex types than any individual exchange will need and define complex types that have more properties, with broader cardinality, than an individual exchange will need. Data definitions within reference schema documents are designed to be a basis that is refined and specialized for a particular exchange. 
 
-Developers of information exchanges are expected to subset, profile, augment, and extend reference schema documents to construct precise data definitions to match their information exchange requirements. However, a schema document thus modified is no longer the authoritative definition of components in its namespace and should not be designated as a reference schema document; it is instead a [subset schema document]() or [message schema document](). 
+Developers of information exchanges are expected to subset, profile, augment, and extend reference schema documents to construct precise data definitions to match their information exchange requirements. However, a schema document thus modified is no longer the authoritative definition of components in its namespace and should not be designated as a reference schema document; it is instead a [subset schema document]() or [message schema document](). There can only be one schema document marked as a reference or extension schema document for a namespace.
 
 ### 4.1.2 Extension schema document
 
@@ -707,7 +710,7 @@ For example, an information exchange specification may define a type for an exch
 * `xs:choice`
 * `xs:any` and `@xs:anyAttribute`
 
-An extension schema document may be intended for a particular information exchange specification.  An extension schema documents may also, like reference schema documents, be optional and over-inclusive, intended for reuse in multiple information exchange specifications. As with reference schema documents, when a developer subsets, profiles, or augments an extension schema document, the result is a subset schema document or message schema document.
+An extension schema document may be intended for a particular information exchange specification.  An extension schema documents may also, like reference schema documents, be optional and over-inclusive, intended for reuse in multiple information exchange specifications. As with reference schema documents, when a developer subsets, profiles, or augments an extension schema document, the result is a subset schema document or message schema document. There can only be one schema document marked as a reference or extension schema document for a namespace.
 
 Note that exchange specifications may define schemas that meet the criteria of reference schemas for those components that its developers wish to nominate for later inclusion in NIEM Core or in domains.
 
@@ -744,7 +747,7 @@ Characteristics of a _message schema document_ include:
 A message schema document provides cardinality and datatype constraints intended to precisely define the content of a particular message format. It is not intended for extension or reuse. Message schema documents are therefore allowed to use schema constructs not allowed in subset schema documents; these include:
 
 * Local type definitions
-* Element declarations with simple type
+* Element declarations with a simple type
 
 ### 4.1.5 Source schema document set
 
@@ -816,74 +819,119 @@ Note that this specification does not require the _document element_ of a _confo
 
 Because each NIEM-conformant element information item must be locally schema-valid, each element must validate against the schema definition of the element, even if the element information item is allowed within the document because of a wildcard that the {process contents} with a value of "skip". As described by [XML Schema Structures](#Appendix-A-References) [Section 3.10.1, _The Wildcard Schema Component_](http://www.w3.org/TR/2004/REC-xmlschema-1-20041028/#process_contents), the content of an element introduced by a wildcard with {process contents} set to "skip" does not have any schema validity constraint; it is only required to be well-formed XML. Within a NIEM-conformant XML document, each element that is from a NIEM namespace conforms to its schema specification.
 
-## Applicability of rules to conformance targets
+## 4.2 Applicability of rules to conformance targets
 
 Each rule within this document is applicable to one or more of the conformance targets identified by [Section 4.1, _Conformance targets defined_, above](#conformance-targets-defined). Each rule identifies its applicability as described in [Section 2.4.1, _Rules_, above](#rules). The applicability field of each rule will contain one or more code values from _Table 4-1, _Codes representing conformance targets_, below_. A rule is applicable to the identified conformance targets.
 
 ### Table 4-1: Codes representing conformance targets
 
-| Code | Target                                                       |
-| ---- | ------------------------------------------------------------ |
-| REF  | [reference schema document]() |
-| EXT  | [extension schema document]() |
-| SUB  | conformant subset schema document                            |
-| MSG  | conformant message schema document                           |
-| SET  | [conformant source schema document set]() |
-| MSET | conformant message schema document set                       |
-| INS  | [conformant instance XML document]() |
+| Code | Target                                     |
+| ---- | ------------------------------------------ |
+| REF  | [reference schema document]()              |
+| EXT  | [extension schema document]()              |
+| SUB  | [subset schema document]()                 |
+| MSG  | [message schema document]()                |
+| SET  | [conformant source schema document set]()  |
+| MSET | [conformant message schema document set]() |
+| INS  | [conformant instance XML document]()       |
 
-## Conformance target identifiers
+## 4.3 Conformance target identifiers
 
 A conformant schema document claims to be conformant thorough the use of a set of _conformance target identifiers_.
 
-### Rule 4-3. Schema is CTAS-conformant
+### Rule 4-1. Schema marked as reference schema document must conform
 
-> **[Rule 4-3] ([REF](#Applicability-of-rules-to-conformance-targets), [EXT](#Applicability-of-rules-to-conformance-targets), [SUB](#Applicability-of-rules-to-conformance-targets), [MSG](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+> **[Rule 4-1] ([SET](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+> Any _schema document_ with an _effective conformance target identifier_ of `https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#ReferenceSchemaDocument` MUST be a _reference schema document_.
+
+### Rule 4-2. Schema marked as extension schema document must conform
+
+> **[Rule 4-2] ([SET](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+> Any _schema document_ with an _effective conformance target identifier_ of `https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#ExtensionSchemaDocument` MUST be an _extension schema document_.
+
+### Rule 4-3. Schema marked as subset schema document must conform
+
+> **[Rule 4-3] ([SET](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+> Any _schema document_ with an _effective conformance target identifier_ of `https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#SubsetSchemaDocument` MUST be a _subset schema document_.
+
+### Rule 4-4. Schema marked as message schema document must conform
+
+> **[Rule 4-4] ([SET](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+> Any _schema document_ with an _effective conformance target identifier_ of `https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#MessageSchemaDocument` MUST be an _message schema document_.
+
+### Rule 4-5. Schema is CTAS-conformant
+
+> **[Rule 4-5] ([REF](#Applicability-of-rules-to-conformance-targets), [EXT](#Applicability-of-rules-to-conformance-targets), [SUB](#Applicability-of-rules-to-conformance-targets), [MSG](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
 > The schema document MUST be a conformant document as defined by the NIEM Conformance Targets Attribute Specification.
 
-The term "conformant document" is defined by [CTAS](#Appendix-A-References) [Section 3.2, _Conformance to this Specification_](http://reference.niem.gov/niem/specification/conformance-targets-attribute/3.0/NIEM-CTAS-3.0-2014-07-31.html#section_3.2).
+The term "conformant document" is defined by [CTAS](#Appendix-A-References) [Section 3.2, _Conformance to this Specification_](https://docs.oasis-open.org/niemopen/ns/specification/conformance-targets-attribute/3.0/NIEM-CTAS-3.0-2014-07-31.html#section_3.2).
 
-### Rule 4-4. Document element has attribute `ct:conformanceTargets`
+### Rule 4-6. Document element has attribute `ct:conformanceTargets`
 
-> **[Rule 4-4] ([REF](#Applicability-of-rules-to-conformance-targets), [EXT](#Applicability-of-rules-to-conformance-targets), [SUB](#Applicability-of-rules-to-conformance-targets), [MSG](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+> **[Rule 4-6] ([REF](#Applicability-of-rules-to-conformance-targets), [EXT](#Applicability-of-rules-to-conformance-targets), [SUB](#Applicability-of-rules-to-conformance-targets), [MSG](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+>
+> ```
+> <sch:pattern>
+>  <sch:rule context="*[. is nf:get-document-element(.)
+>                       or exists(@ct:conformanceTargets)]">
+>    <sch:assert test="(. is nf:get-document-element(.)) = exists(@ct:conformanceTargets)"
+>      >The [document element] of the XML document, and only the [document element], MUST own an attribute {https://docs.oasis-open.org/niemopen/ns/specification/conformanceTargets/3.0/}conformanceTargets.</sch:assert>
+>  </sch:rule>
+> </sch:pattern>
+> ```
 
-```
-<sch:pattern>
- <sch:rule context="*[. is nf:get-document-element(.)
-                      or exists(@ct:conformanceTargets)]">
-   <sch:assert test="(. is nf:get-document-element(.)) = exists(@ct:conformanceTargets)"
-     >The [document element] of the XML document, and only the [document element], MUST own an attribute {http://release.niem.gov/niem/conformanceTargets/3.0/}conformanceTargets.</sch:assert>
- </sch:rule>
-</sch:pattern>
-```
+### Rule 4-7. Schema claims reference schema conformance target
 
-### Rule 4-5. Schema claims reference schema conformance target
-
-> **[Rule 4-5] ([REF](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
-
-```
-<sch:pattern>
- <sch:rule context="*[. is nf:get-document-element(.)]">
-   <sch:assert test="nf:has-effective-conformance-target-identifier(., xs:anyURI(https://docs.oasis-open.org/niemopen/ns/specification/naming-and-design-rules/6.0/#ReferenceSchemaDocument'))"
-     >The document MUST have an effective conformance target identifier of https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#ReferenceSchemaDocument.</sch:assert>
- </sch:rule>
-</sch:pattern>
-```
+> **[Rule 4-7] ([REF](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+>
+>```
+> <sch:pattern>
+>  <sch:rule context="*[. is nf:get-document-element(.)]">
+>    <sch:assert test="nf:has-effective-conformance-target-identifier(., xs:anyURI(https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#ReferenceSchemaDocument'))"
+>      >The document MUST have an effective conformance target identifier of https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#ReferenceSchemaDocument.</sch:assert>
+>  </sch:rule>
+> </sch:pattern>
+> ```
 This document defines the term _effective conformance target identifier_.
 
-### Rule 4-6. Schema claims extension conformance target
+### Rule 4-8. Schema claims extension conformance target
 
-> **[Rule 4-6] ([EXT](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+> **[Rule 4-8] ([EXT](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+>
+> ```
+> <sch:pattern>
+>  <sch:rule context="*[. is nf:get-document-element(.)]">
+>    <sch:assert test="nf:has-effective-conformance-target-identifier(., xs:anyURI(https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#ExtensionSchemaDocument'))"
+>      >The document MUST have an effective conformance target identifier of https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#ExtensionSchemaDocument.</sch:assert>
+>  </sch:rule>
+> </sch:pattern>
+> ```
 
-```
-<sch:pattern>
- <sch:rule context="*[. is nf:get-document-element(.)]">
-   <sch:assert test="nf:has-effective-conformance-target-identifier(., xs:anyURI(https://docs.oasis-open.org/niemopen/ns/specification/naming-and-design-rules/6.0/#ExtensionSchemaDocument'))"
-     >The document MUST have an effective conformance target identifier of https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#ExtensionSchemaDocument.</sch:assert>
- </sch:rule>
-</sch:pattern>
-```
-This document defines the term _effective conformance target identifier_.
+### Rule 4-9. Schema claims subset conformance target
+
+> **[Rule 4-9] ([SUB](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+>
+> ```
+> <sch:pattern>
+>  <sch:rule context="*[. is nf:get-document-element(.)]">
+>    <sch:assert test="nf:has-effective-conformance-target-identifier(., xs:anyURI(https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#SubsetSchemaDocument'))"
+>      >The document MUST have an effective conformance target identifier of https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#SubsetSchemaDocument.</sch:assert>
+>  </sch:rule>
+> </sch:pattern>
+> ```
+
+### Rule 4-10. Schema claims message conformance target
+
+> **[Rule 4-10] ([MSG](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+>
+> ```
+> <sch:pattern>
+>  <sch:rule context="*[. is nf:get-document-element(.)]">
+>    <sch:assert test="nf:has-effective-conformance-target-identifier(., xs:anyURI(https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#MessageSchemaDocument'))"
+>      >The document MUST have an effective conformance target identifier of https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#MessageSchemaDocument.</sch:assert>
+>  </sch:rule>
+> </sch:pattern>
+> ```
 
 # The NIEM conceptual model
 
@@ -1677,8 +1725,7 @@ This document establishes the term _schema document_, by reference to [XML Schem
 
 ### Rule 7-4. Document element is `xs:schema`
 
-> **[Rule 7-4] ([REF](#Applicability-of-rules-to-conformance-targets),
-> [EXT](#Applicability-of-rules-to-conformance-targets), [SUB](#Applicability-of-rules-to-conformance-targets), [MSG](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+> **[Rule 7-4] ([REF](#Applicability-of-rules-to-conformance-targets), [EXT](#Applicability-of-rules-to-conformance-targets), [SUB](#Applicability-of-rules-to-conformance-targets), [MSG](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
 >
 >```xml
 > <sch:pattern>
@@ -2535,10 +2582,10 @@ The type `xs:anySimpleType` does not have any concrete semantics; The use of `xs
 > ```
 
 #### Rule 9-40. Element type not in the XML Schema namespace
-
+>
 > **[Rule 9-40] ([REF](#Applicability-of-rules-to-conformance-targets), [EXT](#Applicability-of-rules-to-conformance-targets), [SUB](#Applicability-of-rules-to-conformance-targets), [MSG](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
-
-```xml
+>
+>```xml
 <sch:pattern>
  <sch:rule context="xs:element[exists(@type)]">
    <sch:assert test="for $type-qname in resolve-QName(@type, .) return
@@ -2547,7 +2594,8 @@ The type `xs:anySimpleType` does not have any concrete semantics; The use of `xs
      >An element type that is not xs:anySimpleType MUST NOT have a namespace name http://www.w3.org/2001/XMLSchema.</sch:assert>
  </sch:rule>
 </sch:pattern>
-```
+>```
+
 The prohibition of element types having the XML Schema namespace subsumes a prohibition of the type `xs:anyType`.
 
 #### Rule 9-41. Element type not in the XML namespace
@@ -4574,9 +4622,7 @@ Acronyms and abbreviations have the ability to improve readability and comprehen
 
 #### Rule 10-51. Names use common abbreviations
 
-> **[Rule 10-51]
-> ([REF](#Applicability-of-rules-to-conformance-targets),
-> [EXT](#Applicability-of-rules-to-conformance-targets), [SUB](#Applicability-of-rules-to-conformance-targets), [MSG](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+> **[Rule 10-51] ([REF](#Applicability-of-rules-to-conformance-targets), [EXT](#Applicability-of-rules-to-conformance-targets), [SUB](#Applicability-of-rules-to-conformance-targets), [MSG](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
 > The schema SHOULD use, in defined names, the abbreviations identified by _Table 10-1, _Abbreviations used in schema component names__, rather than their full meanings.
 
 ##### Table 10-1: Abbreviations used in schema component names
@@ -4833,7 +4879,7 @@ Deprecation can allow version management to be more consistent; versions of sche
 > **[Rule 10-69] ([REF](#Applicability-of-rules-to-conformance-targets), [EXT](#Applicability-of-rules-to-conformance-targets), [SUB](#Applicability-of-rules-to-conformance-targets), [MSG](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
 >
 > ```
-> <sch:pattern>xml
+> <sch:pattern>
 >  <sch:rule context="*[exists(@appinfo:deprecated)]">
 >    <sch:assert test="namespace-uri-from-QName(node-name(.)) = xs:anyURI('http://www.w3.org/2001/XMLSchema')"
 >            >The attribute appinfo:deprecated MUST be owned by an element with a namespace name http://www.w3.org/2001/XMLSchema.</sch:assert>
@@ -4910,12 +4956,19 @@ NIEM provides the structures schema that contains base types for types defined i
 
 The structures namespace is a single namespace, separate from namespaces that define NIEM-conformant data. This document refers to this content via the prefix `structures`.
 
-### Rule 10-78. Use structures consistent with specification
+### Rule 10-78. Source schema uses structures consistent with specification
 
-> **[Rule 10-78] ([REF](#Applicability-of-rules-to-conformance-targets), [EXT](#Applicability-of-rules-to-conformance-targets), [SUB](#Applicability-of-rules-to-conformance-targets), [MSG](#Applicability-of-rules-to-conformance-targets), [INS](#Applicability-of-rules-to-conformance-targets), [SET](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
-> Any schema or instance MUST use the NIEM _structures namespace_ consistent with the schema as it is defined in [Appendix B, _Structures namespace_, below](#appendix-b-structures-namespace).
+>  **[Rule 10-78] ([[SET](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+> A source schema document set MUST use the NIEM _structures namespace_ as defined by the schema document in [Appendix B, _Structures namespace](#appendix-b-structures-namespace) without modification.
 
-This rule further enforces uniform and consistent use of the NIEM `structures` namespace, without addition. Users are not allowed to insert types, attributes, etc. that are not specified by this document. However, users may profile the structures namespace, as needed.
+This rule supports reuse of the components defined by a source schema document set. The `xs:anyAttribute` wildcard allows developers to extend the components in a reference, extension, or subset schema document via attribute augmentation.
+
+### Rule 10-79. Message schema uses structures consistent with specification
+
+> **[Rule 10-79] ([[MSET](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+> A message schema document set MUST use a profile of the NIEM _structures namespace_ as defined by the schema document in [Appendix B,_Structures namespace](#appendix-b-structures-namespace). That profile MUST NOT contain `xs:any` or `xs:anyAttribute`.  That profile MUST NOT include any component not defined by the schema document in [Appendix B, Structures namespace]().  That profile MAY include components defined in reference, extension, or subset schema documents.
+
+This rule supports precise definition of message content by removing the `xs:anyAttribute` wildcard. (The wildcard is unnecessary in message schema document sets, which are not intended to support reuse.)  Developers may remove those attributes defined in the structures namespace that are not needed in a message specification. Developers may augment every element in a message specification by adding elements or attributes from reference, extension, or subset schema documents to the structures schema document.
 
 # 11. Rules for NIEM modeling, by XML Schema component
 
@@ -5114,7 +5167,7 @@ Both of these methods use the element `xs:extension`. Although these two methods
 >        or ends-with(local-name-from-QName($base-qname), 'SimpleType')]">
 >    <sch:assert test="xs:attributeGroup[
 >                        resolve-QName(@ref, .) = xs:QName('structures:SimpleObjectAttributeGroup')]"
->      >A complex type definition with simple content schema component with a derivation method of extension that has a base type definition that is a simple type MUST incorporate the attribute group {http://release.niem.gov/niem/structures/5.0/}SimpleObjectAttributeGroup.</sch:assert>
+>      >A complex type definition with simple content schema component with a derivation method of extension that has a base type definition that is a simple type MUST incorporate the attribute group {https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/}SimpleObjectAttributeGroup.</sch:assert>
 >  </sch:rule>
 > </sch:pattern>
 > ```
@@ -5346,7 +5399,7 @@ This rule is also intended to prevent developers from creating complicated seque
 
 The term _schema document_ is a defined term.
 
-### Attribute use
+### 11.3.3 Attribute use
 
 #### Rule 11-22. Referenced attribute defined by conformant schemas
 
@@ -5354,20 +5407,38 @@ The term _schema document_ is a defined term.
 >
 > ```xml
 > <sch:pattern>
->  <sch:rule context="xs:attribute[@ref]">
->    <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@ref, .))"/>
->    <sch:assert test="some $namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies (
+>   <sch:rule context="xs:attribute[@ref]">
+>      <sch:let name="namespace" value="namespace-uri-from-QName(resolve-QName(@ref, .))"/>
+>      <sch:assert test="some $namespace in namespace-uri-from-QName(resolve-QName(@ref, .)) satisfies (
 >                        $namespace = nf:get-target-namespace(.)
 >                        or ancestor::xs:schema[1]/xs:import[
 >                             @namespace
 >                             and $namespace = xs:anyURI(@namespace)
 >                             and empty(@appinfo:externalImportIndicator)])"
->      >An attribute {}ref MUST have the target namespace or a namespace that is imported as conformant.</sch:assert>
->  </sch:rule>
+>      >An attribute {}ref MUST have the target namespace or a namespace that is imported as conformant.     </sch:assert>
+>   </sch:rule>
 > </sch:pattern>
 > ```
 
-### Wildcard
+#### 11.3.3.1 Attribute group use
+
+#### Rule 11-23. Schema uses only known attribute groups
+
+In conformant schemas, use of attribute groups is restricted. The only attribute group defined by NIEM for use in conformant schemas is structures:SimpleObjectAttributeGroup. This attribute group provides the attributes necessary for IDs, references, metadata, and relationship metadata.
+
+> **[Rule 11-23] ([REF](#Applicability-of-rules-to-conformance-targets), [EXT](#Applicability-of-rules-to-conformance-targets), [SUB](#Applicability-of-rules-to-conformance-targets),  [MSG](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
+>
+> ```xml
+> <sch:pattern>
+>   <sch:rule context="xs:attributeGroup[@ref]">
+>     <sch:assert test="some $ref in resolve-QName(@ref, .) satisfies (
+>                         $ref = xs:QName('structures:SimpleObjectAttributeGroup'))"
+>       >An attribute group reference MUST be structures:SimpleObjectAttributeGroup</sch:assert>
+>   </sch:rule>
+> </sch:pattern>
+> ```
+
+### 11.3.4 Wildcard
 
 NIEM does not define any additional features relating to wildcards. This section is present to maintain with [XML Schema Structures](#Appendix-A-References) [Section 2.2, _XML Schema Abstract Data Model_](http://www.w3.org/TR/2004/REC-xmlschema-1-20041028/#concepts-data-model), See [Section 9.3.4, _Wildcard_, above,](#wildcard) for rules related to wildcards.
 
@@ -5749,7 +5820,7 @@ These rules embody the basic philosophy behind NIEM’s use of components with n
 >                      nf:has-effective-conformance-target-identifier(., xs:anyURI(https://docs.oasis-open.org/niemopen/ns/specification/naming-and-design-rules/6.0/#ReferenceSchemaDocument'))
 >                      and exists(@namespace)
 >                      and empty(@appinfo:externalImportIndicator)
->                      and not(xs:anyURI(@namespace) = (xs:anyURI('http://release.niem.gov/niem/structures/5.0/'),
+>                      and not(xs:anyURI(@namespace) = (xs:anyURI('https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/'),
 >                                                       xs:anyURI('http://www.w3.org/XML/1998/namespace')))]">
 > <sch:assert test="some $schema in nf:resolve-namespace(., @namespace) satisfies
 >                     nf:has-effective-conformance-target-identifier($schema, xs:anyURI(
@@ -6267,129 +6338,80 @@ This specification does not designate order of properties of an object where att
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema
- targetNamespace="http://release.niem.gov/niem/structures/5.0/"
- version="5.0"
- xml:lang="en-US"
- xmlns:structures="http://release.niem.gov/niem/structures/5.0/"
- xmlns:xs="http://www.w3.org/2001/XMLSchema">
-
- <xs:annotation>
-   <xs:documentation>The structures namespace provides base types and other components for definition of NIEM-conformant XML schemas.</xs:documentation>
- </xs:annotation>
-
- <xs:attribute name="id" type="xs:ID">
-   <xs:annotation>
-     <xs:documentation>A document-relative identifier for an XML element.</xs:documentation>
-   </xs:annotation>
- </xs:attribute>
-
- <xs:attribute name="ref" type="xs:IDREF">
-   <xs:annotation>
-     <xs:documentation>A document-relative reference to an XML element.</xs:documentation>
-   </xs:annotation>
- </xs:attribute>
-
- <xs:attribute name="uri" type="xs:anyURI">
-   <xs:annotation>
-     <xs:documentation>An internationalized resource identifier or uniform resource identifier for a node or object.</xs:documentation>
-   </xs:annotation>
- </xs:attribute>
-
- <xs:attribute name="metadata" type="xs:IDREFS">
-   <xs:annotation>
-     <xs:documentation>A list of metadata objects that apply to a node or object represented by an XML element.</xs:documentation>
-   </xs:annotation>
- </xs:attribute>
-
- <xs:attribute name="relationshipMetadata" type="xs:IDREFS">
-   <xs:annotation>
-     <xs:documentation>A list of metadata objects that apply to a relationship or property occurrence represented by an XML element.</xs:documentation>
-   </xs:annotation>
- </xs:attribute>
-
- <xs:attribute name="sequenceID" type="xs:positiveInteger">
-   <xs:annotation>
-     <xs:documentation>An identifier that establishes the relative order of a property occurrence among sibling properties of a node or object.</xs:documentation>
-   </xs:annotation>
- </xs:attribute>
-
- <xs:attributeGroup name="SimpleObjectAttributeGroup">
-   <xs:annotation>
-     <xs:documentation>A group of attributes that are applicable to objects, to be used when defining a complex type that is an extension of a simple type.</xs:documentation>
-   </xs:annotation>
-   <xs:attribute ref="structures:id"/>
-   <xs:attribute ref="structures:ref"/>
-   <xs:attribute ref="structures:uri"/>
-   <xs:attribute ref="structures:metadata"/>
-   <xs:attribute ref="structures:relationshipMetadata"/>
-   <xs:attribute ref="structures:sequenceID"/>
-   <xs:anyAttribute namespace="urn:us:gov:ic:ism urn:us:gov:ic:ntk" processContents="lax"/>
- </xs:attributeGroup>
-
- <xs:complexType name="ObjectType" abstract="true">
-   <xs:annotation>
-     <xs:documentation>A data type for a thing with its own lifespan that has some existence.</xs:documentation>
-   </xs:annotation>
-   <xs:sequence>
-     <xs:element ref="structures:ObjectAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-   </xs:sequence>
-   <xs:attribute ref="structures:id"/>
-   <xs:attribute ref="structures:ref"/>
-   <xs:attribute ref="structures:uri"/>
-   <xs:attribute ref="structures:metadata"/>
-   <xs:attribute ref="structures:relationshipMetadata"/>
-   <xs:attribute ref="structures:sequenceID"/>
-   <xs:anyAttribute namespace="urn:us:gov:ic:ism urn:us:gov:ic:ntk" processContents="lax"/>
- </xs:complexType>
-
- <xs:element name="ObjectAugmentationPoint" abstract="true">
-   <xs:annotation>
-     <xs:documentation>An augmentation point for type structures:ObjectType.</xs:documentation>
-   </xs:annotation>
- </xs:element>
-
- <xs:complexType name="AssociationType" abstract="true">
-   <xs:annotation>
-     <xs:documentation>A data type for a relationship between two or more objects, including any properties of that relationship.</xs:documentation>
-   </xs:annotation>
-   <xs:sequence>
-     <xs:element ref="structures:AssociationAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-   </xs:sequence>
-   <xs:attribute ref="structures:id"/>
-   <xs:attribute ref="structures:ref"/>
-   <xs:attribute ref="structures:uri"/>
-   <xs:attribute ref="structures:metadata"/>
-   <xs:attribute ref="structures:relationshipMetadata"/>
-   <xs:attribute ref="structures:sequenceID"/>
-   <xs:anyAttribute namespace="urn:us:gov:ic:ism urn:us:gov:ic:ntk" processContents="lax"/>
- </xs:complexType>
-
- <xs:element name="AssociationAugmentationPoint" abstract="true">
-   <xs:annotation>
-     <xs:documentation>An augmentation point for type structures:AssociationType.</xs:documentation>
-   </xs:annotation>
- </xs:element>
-
- <xs:complexType name="MetadataType" abstract="true">
-   <xs:annotation>
-     <xs:documentation>A data type for data about data.</xs:documentation>
-   </xs:annotation>
-   <xs:attribute ref="structures:id"/>
-   <xs:attribute ref="structures:ref"/>
-   <xs:attribute ref="structures:uri"/>
-   <xs:anyAttribute namespace="urn:us:gov:ic:ism urn:us:gov:ic:ntk" processContents="lax"/>
- </xs:complexType>
-
- <xs:complexType name="AugmentationType" abstract="true">
-   <xs:annotation>
-     <xs:documentation>A data type for a set of properties to be applied to a base type.</xs:documentation>
-   </xs:annotation>
-   <xs:attribute ref="structures:id"/>
-   <xs:attribute ref="structures:ref"/>
-   <xs:attribute ref="structures:uri"/>
-   <xs:anyAttribute namespace="urn:us:gov:ic:ism urn:us:gov:ic:ntk" processContents="lax"/>
- </xs:complexType>
-
+  targetNamespace="https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/"
+  xmlns:structures="https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  version="6.0"
+  xml:lang="en-US">
+  <xs:annotation>
+    <xs:documentation>The structures namespace provides base types and other components for definition of NIEM-conformant XML schemas.</xs:documentation>
+  </xs:annotation>
+  <xs:attributeGroup name="SimpleObjectAttributeGroup">
+    <xs:attribute ref="structures:id"/>
+    <xs:attribute ref="structures:onlyRef"/>    
+    <xs:attribute ref="structures:qname"/>
+    <xs:attribute ref="structures:ref"/>
+    <xs:attribute ref="structures:uri"/>
+    <xs:anyAttribute processContents="strict" namespace="##other"/>
+  </xs:attributeGroup>
+  <xs:complexType name="AssociationType" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A data type for a relationship between two or more objects, including any properties of that relationship.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element ref="structures:AssociationAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attributeGroup ref="structures:SimpleObjectAttributeGroup"/>
+  </xs:complexType>
+  <xs:complexType name="AugmentationType" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A data type for a set of properties to be applied to a base type.</xs:documentation>
+    </xs:annotation>
+  </xs:complexType>
+  <xs:complexType name="ObjectType" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A data type for a thing with its own lifespan that has some existence.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element ref="structures:ObjectAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attributeGroup ref="structures:SimpleObjectAttributeGroup"/>
+  </xs:complexType>
+  <xs:element name="AssociationAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for type structures:AssociationType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="ObjectAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for type structures:ObjectType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:attribute name="id" type="xs:ID">
+    <xs:annotation>
+      <xs:documentation>A document-relative identifier for an XML element.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="onlyRef" type="xs:boolean">
+    <xs:annotation>
+      <xs:documentation>True if this element is not a property of its parent.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="qname" type="xs:QName">
+    <xs:annotation>
+      <xs:documentation>A uniform resource identifier for a node or object, expressed as a qualified name.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="ref" type="xs:IDREF">
+    <xs:annotation>
+      <xs:documentation>A document-relative reference to an XML element.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="uri" type="xs:anyURI">
+    <xs:annotation>
+      <xs:documentation>An internationalized resource identifier or uniform resource identifier for a node or object.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
 </xs:schema>
 ```
 

--- a/niem-ndr.md
+++ b/niem-ndr.md
@@ -508,22 +508,22 @@ Throughout the document, fragments of XML Schema or XML instances are used to cl
 </xs:complexType>
 ```
 
-# Terminology
+# 3. Terminology
 
 This document uses standard terminology from other standards to explain the principles and rules that describe NIEM. In addition, it defines terms related to these other standards. This section enumerates this externally-dependent terminology.
 
-## IETF Best Current Practice 14 terminology
+## 3.1 IETF Best Current Practice 14 terminology
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [BCP 14](#Appendix-A-References) [RFC 2119](#Appendix-A-References) [RFC 8174](#Appendix-A-References) when, and only when, they appear in all capitals, as shown here.
 
-## XML terminology
+## 3.2 XML terminology
 
 > **[Definition: XML document]**
 > The term "XML document" is as defined by [XML](#Appendix-A-References) [Section 2, _Documents_](http://www.w3.org/TR/2008/REC-xml-20081126/#dt-xml-doc), which states:
 
 >> A data object is an XML document if it is well-formed, as defined in this specification. In addition, the XML document is valid if it meets certain further constraints.
 
-## XML Information Set terminology
+## 3.3 XML Information Set terminology
 
 When discussing XML documents, this document uses terminology and language as defined by [XML Infoset](#Appendix-A-References).
 
@@ -544,7 +544,7 @@ Shorthand terms for properties of information items include:
 - owner (of an attribute): the value of the [owner element] property of an attribute information item
 - document element: the value of the [document element] property of a document information item; preferred over the term "root element".
 
-## XML Schema terminology
+## 3.4 XML Schema terminology
 
 This document uses many terms from [XML Schema Structures](#Appendix-A-References) and [XML Schema Datatypes](#Appendix-A-References) in a normative way.
 
@@ -560,7 +560,7 @@ Note that this defines an abstract concept. This is not a direct reference to el
 
 >> An **XML Schema** is a set of schema components.
 
-Note, again, that this is an abstract concept: the set of abstract _schema components_ that are put together to define a schema against which an XML document might be validated.
+In this document, the term "schema" is shorthand for "XML Schema". Note, again, that this is an abstract concept: the set of abstract _schema components_ that are put together to define a schema against which an XML document might be validated.
 
 > **[Definition: XML Schema definition language]**
 > The term "XML Schema definition language" is as defined by [XML Schema Structures](#Appendix-A-References) [subsection _Abstract_](http://www.w3.org/TR/2004/REC-xmlschema-1-20041028/#abstract), which states:
@@ -600,7 +600,7 @@ The term "instance document" is used with [XML Schema Structures](#Appendix-A-Re
 
 Schema assembly is a tricky topic that is not resolved by this document. Other specifications may express specifics about the process of turning a set of _schema documents_ into an _XML Schema_. Methods used may include use of tool-specific schema caches and mappings, use of XML catalogs and entity resolvers, use of `schemaLocation` attributes on `xs:import` elements, and `xsi:schemaLocation` attributes in XML documents, among others. The topic of schema assembly is discussed in [Section 6.2.10, _Schema locations provided in schema documents are hints_, below](#schema-locations-provided-in-schema-documents-are-hints). This specification abstracts away details of schema assembly through the use of XPath functions described by [Section 2.4.3, _Normative XPath functions_, above](#normative-xpath-functions).
 
-### Schema components
+### 3.4.1 Schema components
 
 In this document, the name of a referenced schema component may appear without the suffix "schema component" to enhance readability of the text. For example, the term "complex type definition" may be used instead of "complex type definition schema component".
 
@@ -618,7 +618,7 @@ In this document, the name of a referenced schema component may appear without t
 > **[Definition: element declaration]**
 > The term "element declaration" is as defined by [XML Schema Structures](#Appendix-A-References) [Section 2.2.2.1, _Element Declaration_](http://www.w3.org/TR/2004/REC-xmlschema-1-20041028/#Element_Declaration).
 
-### Schema information set contributions
+### 3.4.2 Schema information set contributions
 
 As described in [Section 3.3, _XML Information Set terminology_, above](#xml-information-set-terminology), the XML Information Set specification defined properties of the content of XML documents. The XML Schema specification also provides properties of the content of XML documents. These properties are called Schema information set contribution, as described by [XML Schema Structures](#Appendix-A-References) [Section 2.3, _Constraints and Validation Rules_](http://www.w3.org/TR/2004/REC-xmlschema-1-20041028/#gloss-sic), which defines them as:
 
@@ -628,11 +628,11 @@ This document uses these property terms within definitions and other text. Terms
 
 - [[type definition] (of an element)](http://www.w3.org/TR/2004/REC-xmlschema-1-20041028/#e-type_definition): The type of the element as determined at run-time. This will reflect the use of the attribute `xsi:type` in an XML document.
 
-## XML Namespaces terminology
+## 3.5 XML Namespaces terminology
 
 This document uses XML Namespaces as defined by [XML Namespaces](#Appendix-A-References).
 
-## Conformance Targets Attribute Specification terminology
+## 3.6 Conformance Targets Attribute Specification terminology
 
 [CTAS](#Appendix-A-References) defines several terms used normatively within this specification.
 
@@ -651,9 +651,9 @@ This document uses XML Namespaces as defined by [XML Namespaces](#Appendix-A-Ref
 
 >> An _effective conformance target identifier_ of a conformant document is an internationalized resource identifier reference that occurs in the document’s effective conformance targets attribute.
 
-# Conformance targets
+# 4. Conformance targets
 
-## Conformance targets defined
+## 4.1 Conformance targets defined
 
 This section defines and describes conformance targets of this specification. Each conformance target has a formal definition, along with a notional description of the characteristics and intent of each. These include:
 
@@ -662,7 +662,7 @@ This section defines and describes conformance targets of this specification. Ea
 - [Section 4.1.3, _Schema document set_](#schema-document-set)
 - [Section 4.1.4, _Instance documents and elements_](#instance-documents-and-elements)
 
-### Reference schema document
+### 4.1.1 Reference schema document
 
 > **[Definition: reference schema document]**
 > A **reference schema document** is a _schema document_ that is intended to provide the authoritative definitions of broadly reusable _schema components_. It is a _conformance target_ of this specification. A reference schema document MUST conform to all rules of this specification that apply to this conformance target. An _XML document_ with a _conformance target identifier_ of `https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#ReferenceSchemaDocument` MUST be a conformant reference schema document.
@@ -672,7 +672,7 @@ A _reference schema document_ is a _schema document_ that is intended to be the 
 Some characteristics of a _reference schema document_:
 
 - It is explicitly designated as a reference schema via the conformance targets attribute, per [Rule 4-5, _Schema claims reference schema conformance target_ (REF), below](#rule-4-5-schema-claims-reference-schema-conformance-target).
-- It provides the broadest, most fundamental definitions of components in its namespace.
+- It provides the broadest, most fundamental definitions of components in its namespace, omitting cardinality and datatype constraints unless these are essential to the meaning of the component.
 - It provides the authoritative definition of business semantics for components in its namespace.
 - It is intended to serve as the basis for components in information exchanges and extension schema documents.
 - It satisfies all rules specified in the Naming and Design Rules for reference schemas.
@@ -681,35 +681,102 @@ Any schema that defines components that are intended to be incorporated into NIE
 
 The rules for reference schema documents are more stringent than are the rules for other classes of NIEM-conformant schemas. Reference schema documents are intended to support the broadest reuse. They are very uniform in their structure. As they are the primary definitions for schema components, they do not need to restrict other data definitions, and they are not allowed to use XML Schema’s restriction mechanism (e.g., [Rule 9-30, _Complex content uses extension_ (REF), below](#rule-9-30-complex-content-uses-extension)). Reference schema documents are intended to be as regular and simple as possible.
 
-Many reference schemas are **optional and over-inclusive**. Data definitions in namespaces defined by reference schemas are designed with parts that are intended to be omitted or refined as needed for a particular exchange. Many reference schemas define more complex types than any individual exchange will need and define complex types that have more properties, with broader cardinality, than an individual exchange will need. Data definitions within reference schemas are designed to be a basis that is refined and specialized for a particular exchange. Developers of information exchanges are expected to subset, profile, and extend reference schemas to construct precise data definitions to match their information exchange requirements.
+Many reference schema documents are **optional and over-inclusive**. Data definitions in namespaces defined by reference schema documents are designed with parts that are intended to be omitted or refined as needed for a particular exchange. Many reference schema documents define more complex types than any individual exchange will need and define complex types that have more properties, with broader cardinality, than an individual exchange will need. Data definitions within reference schema documents are designed to be a basis that is refined and specialized for a particular exchange. 
 
-### Extension schema document
+Developers of information exchanges are expected to subset, profile, augment, and extend reference schema documents to construct precise data definitions to match their information exchange requirements. However, a schema document thus modified is no longer the authoritative definition of components in its namespace and should not be designated as a reference schema document; it is instead a [subset schema document]() or [message schema document](). 
+
+### 4.1.2 Extension schema document
 
 > **[Definition: extension schema document]**
-> An **extension schema document** is a _schema document_ that is intended to provide definitions of _schema components_ that are intended for reuse within a more narrow scope than those defined by a _reference schema document_. It is a _conformance target_ of this specification. An extension schema document MUST conform to all rules of this specification that apply to this conformance target. An XML document with a _conformance target identifier_ of `https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#ExtensionSchemaDocument` MUST be an extension schema document.
+> An **extension schema document** is a _schema document_ that is intended to provide authoritative definitions of _schema components_ intended for reuse within a more narrow scope than those defined by a _reference schema document_. It is a _conformance target_ of this specification. An extension schema document MUST conform to all rules of this specification that apply to this conformance target. An XML document with a _conformance target identifier_ of `https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#ExtensionSchemaDocument` MUST be an extension schema document.
 
 Characteristics of an _extension schema document_ include:
 
 - It is explicitly designated as an _extension schema document_ via the conformance targets attribute.
 - It provides the authoritative definition of business semantics for components in its namespace.
 - It contains components that, when appropriate, use or are derived from the components in _reference schema documents_.
-- It is intended to express the additional vocabulary required for an information exchange, above and beyond the vocabulary available from reference schemas, and to also support additional XML Schema validation requirements for an exchange.
+- It is intended to express the additional vocabulary required for one or more information exchanges, above and beyond the vocabulary available from reference schemas, and to also support additional XML Schema validation requirements for those exchanges.
 - It satisfies all rules specified in this document for _extension schema documents_.
 
-An extension schema in an information exchange specification serves several functions. First, it defines new content within a new namespace, which may be an exchange-specific namespace or a namespace shared by several exchanges. This content is NIEM-conformant but has fewer restrictions on it than do _reference schema documents_. Second, the _extension schema document_ bases its content on content from _reference schema documents_, where appropriate. Methods of deriving content include using (by reference) existing _schema components_, as well as creating extensions and restrictions of existing components.
+An extension schema serves several functions. First, it defines new content within a new namespace, which may be an exchange-specific namespace or a namespace shared by several exchanges. This content is NIEM-conformant but has fewer restrictions on it than do _reference schema documents_. Second, the _extension schema document_ bases its content on content from _reference schema documents_, where appropriate. Methods of deriving content include using (by reference) existing _schema components_, as well as creating extensions and restrictions of existing components.
 
-For example, an information exchange specification may define a type for an exchange-specific phone number and base that type on a type defined by the NIEM Core reference schema document. This exchange-specific phone number type may restrict the NIEM Core type to limit those possibilities that are permitted of the base type. Exchange extensions and restrictions must include annotations and documentation to be conformant, but they are allowed to use restriction, choice, and some other constructs that are not allowed in _reference schema documents_.
+For example, an information exchange specification may define a type for an exchange-specific phone number and base that type on a type defined by the NIEM Core reference schema document. This exchange-specific phone number type may restrict the NIEM Core type to limit those possibilities that are permitted of the base type. Exchange schema documents must include annotations and documentation to be conformant, but they are allowed to use some schema constructs that are not allowed in _reference schema documents_; these include:
+
+* `@final`, `@fixed`,  and`@block`,
+* `@blockDefault` and `@finalDefault`
+* `xs:choice`
+* `xs:any` and `@xs:anyAttribute`
+
+An extension schema document may be intended for a particular information exchange specification.  An extension schema documents may also, like reference schema documents, be optional and over-inclusive, intended for reuse in multiple information exchange specifications. As with reference schema documents, when a developer subsets, profiles, or augments an extension schema document, the result is a subset schema document or message schema document.
 
 Note that exchange specifications may define schemas that meet the criteria of reference schemas for those components that its developers wish to nominate for later inclusion in NIEM Core or in domains.
 
-### Schema document set
+### 4.1.3 Subset schema document
 
-A _conformant schema document set_ is a set of schema documents that are capable of validating XML documents.
+> **[Definition: subset schema document]**
+> A **subset schema document** is a _schema document_ providing a constrained selection of components that are defined in a reference or extension schema document. It is a _conformance target_ of this specification. A subset schema document MUST conform to all rules of this specification that apply to this conformance target. An XML document with a _conformance target identifier_ of `https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#SubsetSchemaDocument` MUST be a subset schema document.
 
-> **[Definition: conformant schema document set]**
-> A **conformant schema document set** is a collection of _schema documents_ that together are capable of _validating_ a _conformant instance XML document_. It is a _conformance target_ of this specification. A conformant schema document set MUST conform to all rules of this specification that apply to this conformance target.
+Characteristics of a _subset schema document_ include:
 
-A _conformant schema document set_ has strong dependencies on _reference schema documents_ and _extension schema documents_. Without the guarantees provided by those conformance targets, the rules for a _conformant schema document set_ would not be helpful. Those schemas in a schema set that are marked as reference or extension schemas are required to conform to the appropriate conformance targets.
+- It is explicitly designated as an subset schema document via the conformance targets attribute.
+- It supplies but does not alter the definition of business semantics for components defined by the reference or extension schema document for its namespace. 
+- It does not provide original definitions and declarations for schema components; it contains only components defined by the reference or extension schema document for its namespace. 
+- It removes or constrains portions of the reference or extension schema document for its namespace, thereby building a profile of that schema document.
+- All content that is valid against the subset schema document is also valid against the reference or extension schema document for its namespace.
+- It satisfies all rules specified in this document for _subset schema documents_.
+
+A subset schema document is usually intended for a particular information exchange specification. Developers may also create a subset schema document for reuse in many specifications as a profile of an extension schema document that they do not control.
+
+Subset schema documents are allowed to use some schema constructs that are not allowed in _extension schema documents_; these include `@default` and `@fixed`.
+
+### 4.1.4 Message schema document
+
+> **[Definition: message schema document]**
+> A **message schema document** is a _schema document_ providing a constrained selection of components that are defined in a reference or extension schema document. It is a _conformance target_ of this specification. A message schema document MUST conform to all rules of this specification that apply to this conformance target. An XML document with a _conformance target identifier_ of `https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#MessageSchemaDocument` MUST be a message schema document.
+
+Characteristics of a _message schema document_ include:
+
+- It is explicitly designated as a message schema document via the conformance targets attribute.
+- It does not conform to rules for mapping schema components into business semantics. Semantics are provided by the reference or extension schema document for its namespace.
+- It constrains the reference or extension schema document for its namespace, with more precision and granularity than is possible in a subset schema document.
+- It satisfies all rules specified in this document for _message schema documents_.
+
+A message schema document provides cardinality and datatype constraints intended to precisely define the content of a particular message format. It is not intended for extension or reuse. Message schema documents are therefore allowed to use schema constructs not allowed in subset schema documents; these include:
+
+* Local type definitions
+* Element declarations with simple type
+
+### 4.1.5 Source schema document set
+
+A _conformant source schema document set_ is a set of schema documents that together define a complete data model suitable for reuse.
+
+> **[Definition: conformant source schema document set]**
+> A **conformant source schema document set** is a collection of _schema documents_ that together define a complete data model suitable for reuse. It is a _conformance target_ of this specification. A conformant schema document set MUST conform to all rules of this specification that apply to this conformance target.
+
+Characteristics of a source schema document set include:
+
+* It contains the definition of every schema component referenced by any component defined by the schema set. 
+* It is intended for reuse; developers may subset, profile, augment, and extend the components defined by the schema set.
+* It supports element augmentations and attribute augmentations (see [section 10.4: Augmentations]()).
+* It is not intended for validation of a conformant instance XML document.
+* It does not include message schema documents.
+
+A _conformant source schema document set_ has strong dependencies on _reference schema documents_ and _extension schema documents_. Without the guarantees provided by those conformance targets, the rules for a _conformant schema document set_ would not be helpful. Those schema documents in a schema set that are marked as reference or extension schema documents are required to conform to the appropriate conformance targets. A schema document not marked as conformant must be imported as an _external schema document_ (see [section 10.2.3: External adapter types and external components]()).
+
+### 4.1.6 Message schema document set
+
+ A *conformant message schema document set* is a set of schema documents that are capable of validating a conformant instance XML document.
+
+> **[Definition: conformant message schema document set]**
+> A **conformant message schema document set** is a collection of _schema documents_ that together are capable of _validating_ a _conformant instance XML document_. It is a _conformance target_ of this specification. A conformant schema document set MUST conform to all rules of this specification that apply to this conformance target.
+
+Characteristics of a message schema document set include:
+
+* It contains the definition of every schema component referenced by any component defined by the schema set. 
+* It is not intended for reuse.
+* It does not support attribute augmentation.
+* It is intended for validation of a conformant instance XML document.
+* It may include reference, extension, subset, and message schema documents.
 
 ### Rule 4-1. Schema marked as reference schema document must conform
 
@@ -721,17 +788,17 @@ A _conformant schema document set_ has strong dependencies on _reference schema 
 > **[Rule 4-2] ([SET](#Applicability-of-rules-to-conformance-targets)) (Constraint)**
 > Any _schema document_ with an _effective conformance target identifier_ of `https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#ExtensionSchemaDocument` MUST be an _extension schema document_.
 
-### Instance documents and elements
+### 4.1.7 Instance documents and elements
 
 This document has specific rules about how NIEM content should be used in XML documents. As well as containing rules for XML Schema documents, this NDR contains rules for NIEM-conformant XML content at a finer granularity than the XML document.
 
 > **[Definition: conformant instance XML document]**
-> A **conformant instance XML document** is an _XML document_ that is an _instance document_         _valid_ to a _conformant schema document set_. It is a _conformance target_ of this specification. A conformant instance XML document MUST conform to all rules of this specification that apply to this conformance target.
+> A **conformant instance XML document** is an _XML document_ that is an _instance document_ _valid_ to a _conformant message schema document set_. It is a _conformance target_ of this specification. A conformant instance XML document MUST conform to all rules of this specification that apply to this conformance target.
 
 Characteristics of a _conformant instance XML document_ include:
 
 - The _document element_ is locally schema-valid.
-- Each element information item within the _XML document_ that has property [namespace name] matching the target namespace of a _reference schema document_ or _extension schema document_ is a _conformant element information item_.
+- Each element information item within the _XML document_ that has property [namespace name] matching the target namespace of a _reference schema document_ or _extension schema document_ or _message schema document_ in the document set is a _conformant element information item_.
 
 Schema-validity may be assessed against a single set of schemas or against multiple sets of schemas.
 
@@ -742,7 +809,7 @@ Note that this specification does not require the _document element_ of a _confo
 > **[Definition: conformant element information item]**
 > A _conformant element information item_ is an element information item that satisfies all of the following criteria:
 
-- Its [namespace name] and [local name] matches an element declared by a _reference schema document_ or _extension schema document_.
+- Its [namespace name] and [local name] matches an element declared by a _reference schema document_ or _extension schema document_ or _message schema document_ in a _message schema document set_.
 - It occurs within a _conformant instance XML document_.
 - It is locally schema-valid.
 - It satisfies all rules specified in this document applicable to an element in a _conformant instance XML document_.

--- a/ruleMatrix.md
+++ b/ruleMatrix.md
@@ -1,60 +1,61 @@
-## Matrix of rules and conformance targets
-
-> This is a working document. It wil eventually vanish, merge, or something.
 
 **Applicable only to reference schema documents**
 
 | Number | Rule | REF | EXT | SUB | MSG |
 | --- | --- | :-: | :-: | :-: | :-: |
-| 9-11 | No simple type disallowed derivation  | X|  |  |   |
-| 9-13 | No use of "fixed" on simple type facets  | X|  |  |   |
-| 9-30 | Complex content uses extension  | X|  |  |   |
-| 9-33 | Simple content uses extension  | X|  |  |   |
-| 9-34 | No complex type disallowed substitutions  | X|  |  |   |
-| 9-35 | No complex type disallowed derivation  | X|  |  |   |
-| 9-43 | No element disallowed substitutions  | X|  |  |   |
-| 9-44 | No element disallowed derivation  | X|  |  |   |
-| 9-47 | Element declaration is nillable  | X|  |  |   |
-| 9-62 | `xs:sequence` must be child of `xs:extension`  | X|  |  |   |
-| 9-64 | No `xs:choice`  | X|  |  |   |
-| 9-70 | No use of `xs:any`  | X|  |  |   |
-| 9-71 | No use of `xs:anyAttribute`  | X|  |  |   |
-| 9-86 | No disallowed substitutions  | X|  |  |   |
-| 9-87 | No disallowed derivations  | X|  |  |   |
-| 10-13 | External attribute use only in external adapter type  | X|  |  |   |
-| 10-23 | Augmentable type has augmentation point element  | X|  |  |   |
-| 10-29 | Augmentation point element use is optional  | X|  |  |   |
-| 10-30 | Augmentation point element use is unbounded  | X|  |  |   |
-| 10-37 | Augmentation elements are not used directly  | X|  |  |   |
+| 9-11 | No simple type disallowed derivation  | X |   |   |   |
+| 9-13 | No use of "fixed" on simple type facets  | X |   |   |   |
+| 9-30 | Complex content uses extension  | X |   |   |   |
+| 9-33 | Simple content uses extension  | X |   |   |   |
+| 9-34 | No complex type disallowed substitutions  | X |   |   |   |
+| 9-35 | No complex type disallowed derivation  | X |   |   |   |
+| 9-43 | No element disallowed substitutions  | X |   |   |   |
+| 9-44 | No element disallowed derivation  | X |   |   |   |
+| 9-47 | Element declaration is nillable  | X |   |   |   |
+| 9-62 | `xs:sequence` must be child of `xs:extension`  | X |   |   |   |
+| 9-64 | No `xs:choice`  | X |   |   |   |
+| 9-70 | No use of `xs:any`  | X |   |   |   |
+| 9-71 | No use of `xs:anyAttribute`  | X |   |   |   |
+| 9-86 | No disallowed substitutions  | X |   |   |   |
+| 9-87 | No disallowed derivations  | X |   |   |   |
+| 10-13 | External attribute use only in external adapter type  | X |   |   |   |
+| 10-23 | Augmentable type has augmentation point element  | X |   |   |   |
+| 10-29 | Augmentation point element use is optional  | X |   |   |   |
+| 10-30 | Augmentation point element use is unbounded  | X |   |   |   |
+| 10-37 | Augmentation elements are not used directly  | X |   |   |   |
 
- **Applicable to reference and externsion schema documents**
+**Applicable to reference and extension schema documents**
+
 | Number | Rule | REF | EXT | SUB | MSG |
 | --- | --- | :-: | :-: | :-: | :-: |
-| 9-45 | No element default value  | X | X|  |   |
-| 9-46 | No element fixed value  | X | X|  |   |
-| 9-57 | No attribute default values  | X | X|  |   |
-| 9-58 | No fixed values for optional attributes  | X | X|  |   |
+| 9-45 | No element default value  | X | X |   |   |
+| 9-46 | No element fixed value  | X | X |   |   |
+| 9-57 | No attribute default values  | X | X |   |   |
+| 9-58 | No fixed values for optional attributes  | X | X |   |   |
 
 **Applicable to reference, extension, and subset schema documents**
-| Number | Rule | REF | EXT | SUB | MSG |
-| --- | --- | :-: | :-: | :-: | :-: |
-| 9-10 | Simple type definition is top-level  | X | X | X|   |
-| 9-25 | Complex type definition is top-level  | X | X | X|   |
-| 9-42 | Element type is not simple type  | X | X | X|   |
-| 10-2 | Object type with complex content is derived from `structures:ObjectType`  | X | X | X|   |
-| 10-20 | Proxy type has designated structure  | X | X | X|   |
-| 10-21 | Association type derived from `structures:AssociationType`  | X | X | X|   |
-| 10-22 | Association element type is an association type  | X | X | X|   |
-| 11-8 | Name of a code simple type ends in "CodeSimpleType"  | X | X | X|   |
-| 11-11 | Complex type with simple content has `structures:SimpleObjectAttributeGroup`  | X | X | X|   |
 
-**Applicable to reference, extension, subset, and message schema documents**
+| Number | Rule | REF | EXT | SUB | MSG |
+| :-- | :-- | :-- | :-- | :-- | :-- |
+| 9-10 | Simple type definition is top-level  | X | X | X |   |
+| 9-25 | Complex type definition is top-level  | X | X | X |   |
+| 9-42 | Element type is not simple type  | X | X | X |   |
+| 10-2 | Object type with complex content is derived from `structures:ObjectType`  | X | X | X |   |
+| 10-20 | Proxy type has designated structure  | X | X | X |   |
+| 10-21 | Association type derived from `structures:AssociationType`  | X | X | X |   |
+| 10-22 | Association element type is an association type  | X | X | X |   |
+| 11-8 | Name of a code simple type ends in "CodeSimpleType"  | X | X | X |   |
+| 11-11 | Complex type with simple content has `structures:SimpleObjectAttributeGroup`  | X | X | X |   |
+
+**Applicable to all schema documents**
+
 | Number | Rule | REF | EXT | SUB | MSG |
 | --- | --- | :-: | :-: | :-: | :-: |
-| 4-3 | Schema is CTAS-conformant  | X |  X | X  | X   |
-| 4-4 | Document element has attribute `ct:conformanceTargets`  | X | X  | X | X  |
-| 7-3 | Document is a schema document  | X | X | X  | X |
-| 7-4 | Document element is `xs:schema`  | X| X | X | X |
+| 7-1 | Document is an XML document  | X | X | X | X |
+| 7-2 | Document uses XML namespaces properly  | X | X | X | X |
+| 7-3 | Document is a schema document  | X | X | X | X |
+| 7-4 | Document element is `xs:schema`  | X | X | X | X |
+| 7-5 | Component name follows ISO 11179 Part 5 Annex A  | X | X | X | X |
 | 9-1 | No base type in the XML namespace  | X | X | X | X |
 | 9-2 | No base type of `xs:ID`  | X | X | X | X |
 | 9-3 | No base type of `xs:IDREF`  | X | X | X | X |
@@ -97,12 +98,7 @@
 | 9-55 | No attribute type of `xs:ENTITIES`  | X | X | X | X |
 | 9-56 | No attribute type of `xs:anySimpleType`  | X | X | X | X |
 | 9-59 | No use of element `xs:notation`  | X | X | X | X |
-| 9-60 | Model group does not affect meaning | * | X | X | X |
 | 9-61 | No `xs:all`  | X | X | X | X |
-| 9-63 | `xs:sequence` must be child of `xs:extension` or `xs:restriction` | * | X | X | X |
-| 9-65 | `xs:choice` must be child of `xs:sequence` | * | X | X | X |
-| 9-68 | Choice has minimum cardinality 1 | * | X | X | X |
-| 9-69 | Choice has maximum cardinality 1 | * | X | X | X |
 | 9-66 | Sequence has minimum cardinality 1  | X | X | X | X |
 | 9-67 | Sequence has maximum cardinality 1  | X | X | X | X |
 | 9-72 | No use of `xs:unique`  | X | X | X | X |
@@ -158,6 +154,7 @@
 | 10-48 | Names use camel case  | X | X | X | X |
 | 10-49 | Attribute name begins with lower case letter  | X | X | X | X |
 | 10-50 | Name of schema component other than attribute and proxy type begins with upper case letter  | X | X | X | X |
+| 10-51 | Names use common abbreviations  | X | X | X | X |
 | 10-52 | Local term declaration is local to its schema document  | X | X | X | X |
 | 10-53 | Local terminology interpretation  | X | X | X | X |
 | 10-54 | Singular form is preferred in name  | X | X | X | X |
@@ -180,7 +177,6 @@
 | 10-71 | External adapter type indicator annotates complex type  | X | X | X | X |
 | 10-76 | `appinfo:LocalTerm` annotates schema  | X | X | X | X |
 | 10-77 | `appinfo:LocalTerm` has literal or definition  | X | X | X | X |
-| 10-78 | Use structures consistent with specification  | X | X | X | X |
 | 11-1 | Name of type ends in "Type"  | X | X | X | X |
 | 11-2 | Only types have name ending in "Type" or "SimpleType"  | X | X | X | X |
 | 11-3 | Base type definition defined by conformant schema  | X | X | X | X |
@@ -200,6 +196,7 @@
 | 11-20 | Element or attribute declaration introduced only once into a type  | X | X | X | X |
 | 11-21 | Element reference defined by conformant schema  | X | X | X | X |
 | 11-22 | Referenced attribute defined by conformant schemas  | X | X | X | X |
+| 11-23 | Schema uses only known attribute groups  | X | X | X | X |
 | 11-24 | Data definition does not introduce ambiguity  | X | X | X | X |
 | 11-25 | Object class has only one meaning  | X | X | X | X |
 | 11-26 | Data definition of a part does not redefine the whole  | X | X | X | X |
@@ -229,6 +226,3 @@
 | 11-52 | Structures imported as conformant  | X | X | X | X |
 | 11-53 | XML namespace imported as conformant  | X | X | X | X |
 | 11-55 | Consistently marked namespace imports  | X | X | X | X |
- 7-1 | Document is an XML document  | X | X | X | X |
- 7-2 | Document uses XML namespaces properly  | X | X | X | X |
- 7-5 | Component name follows ISO 11179 Part 5 Annex A  | X | X | X | X |


### PR DESCRIPTION
1. Revised section 4 (conformance targets)
2. Revised section 10.10 (NIEM structural facilities)
3. Resurrected rule 11-23 (turns out NDR is much easier to write with SimpleObjectAttributeGroup)
4. Wrote "makerules" script to generate SCH files from niem-ndr.md
5. Replaced appendix B (structures namespace)